### PR TITLE
Remove unused layout import

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -15,8 +15,6 @@ export(restore_spatial_structure)
 
 # Visualization functions
 export(plot_spatial_maps)
-export(plot_hrf_estimates)
-export(plot_state_sequence)
 
 # HRF utilities extending fmrireg
 export(create_hrf_basis_neuroim2)

--- a/R/continuous_linear_decoder.R
+++ b/R/continuous_linear_decoder.R
@@ -629,7 +629,7 @@ plot.ContinuousLinearDecoder <- function(x, type = c("convergence", "states", "m
     old_par <- par(no.readonly = TRUE)
     on.exit(par(old_par))
     
-    layout(matrix(c(1, 2, 3, 3), 2, 2, byrow = TRUE))
+    graphics::layout(matrix(c(1, 2, 3, 3), 2, 2, byrow = TRUE))
     
     # 1. Convergence
     if (length(x$get_diagnostics()$objective_values) > 0) {

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -21,8 +21,8 @@ NULL
 #' 
 #' @return Invisible NULL, plots are displayed
 #' @export
-#' @importFrom graphics par image layout
-plot_spatial_maps <- function(W, layout = NULL, zlim = NULL, 
+#' @importFrom graphics par image
+plot_spatial_maps <- function(W, layout = NULL, zlim = NULL,
                               col = heat.colors(100), titles = NULL, mask = NULL) {
   # Handle NeuroVol input
   if (is.list(W) && all(sapply(W, inherits, "NeuroVol"))) {
@@ -262,7 +262,7 @@ plot_diagnostics <- function(decoder_output, which = 1:4, ...) {
   
   n_plots <- length(which)
   layout_matrix <- matrix(c(1:n_plots, rep(0, 4-n_plots)), 2, 2, byrow = TRUE)
-  layout(layout_matrix)
+  graphics::layout(layout_matrix)
   
   for (i in which) {
     if (i == 1 && !is.null(decoder_output$W)) {


### PR DESCRIPTION
## Summary
- remove layout from graphics imports in visualization functions
- call `graphics::layout()` explicitly
- drop stale exports from `NAMESPACE`

## Testing
- `R` not installed, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_683a78855500832d892b56d23cbb365a