### PR TITLE
Add input validation to simulate_fmri_data

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -71,6 +71,28 @@ simulate_fmri_data <- function(V = 1000, T = 200, K = 3, rank = NULL,
   if (is.null(rank)) {
     rank <- min(V, K, 20)  # Cap at 20 for efficiency
   }
+
+  # Ensure core parameters are positive integers
+  if (!is.numeric(V) || length(V) != 1 || V <= 0 || V != as.integer(V)) {
+    stop("V must be a positive integer")
+  }
+  if (!is.numeric(T) || length(T) != 1 || T <= 0 || T != as.integer(T)) {
+    stop("T must be a positive integer")
+  }
+  if (!is.numeric(K) || length(K) != 1 || K <= 0 || K != as.integer(K)) {
+    stop("K must be a positive integer")
+  }
+  if (!is.numeric(rank) || length(rank) != 1 || rank <= 0 || rank != as.integer(rank)) {
+    stop("rank must be a positive integer")
+  }
+  if (!is.null(dims)) {
+    if (length(dims) != 3) {
+      stop("dims must have length 3")
+    }
+    if (prod(dims) != V) {
+      stop("product of dims must equal V")
+    }
+  }
   
   # Validate inputs
   if (return_neuroim && is.null(dims)) {

--- a/tests/testthat/test-simulate-input-validation.R
+++ b/tests/testthat/test-simulate-input-validation.R
@@ -1,0 +1,19 @@
+library(stance)
+
+test_that("simulate_fmri_data validates integer inputs", {
+  expect_error(simulate_fmri_data(V = -10, T = 50, K = 2), "V must be a positive integer")
+  expect_error(simulate_fmri_data(V = 10, T = 0, K = 2), "T must be a positive integer")
+  expect_error(simulate_fmri_data(V = 10, T = 50, K = 0), "K must be a positive integer")
+  expect_error(simulate_fmri_data(V = 10, T = 50, K = 2, rank = -1), "rank must be a positive integer")
+})
+
+test_that("simulate_fmri_data validates dims argument", {
+  expect_error(
+    simulate_fmri_data(V = 27, T = 20, K = 2, return_neuroim = TRUE, dims = c(3, 3)),
+    "dims must have length 3"
+  )
+  expect_error(
+    simulate_fmri_data(V = 27, T = 20, K = 2, return_neuroim = TRUE, dims = c(3, 3, 4)),
+    "product of dims must equal V"
+  )
+})


### PR DESCRIPTION
## Summary
- validate integer parameters in `simulate_fmri_data`
- check optional `dims` argument
- add tests covering new validations

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a78444eac832dbd982d42fa5939b7