### PR TITLE
Fix zero-SNR simulation handling

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -119,9 +119,15 @@ simulate_fmri_data <- function(V = 1000, T = 200, K = 3, rank = NULL,
   # Combine signal and noise based on SNR
   signal_power <- mean(signal^2)
   noise_power <- mean(noise^2)
-  noise_scaled <- noise * sqrt(signal_power / (snr * noise_power))
-  
-  Y <- signal + noise_scaled
+
+  if (snr <= 0) {
+    # Avoid division by zero or negative scaling
+    noise_scaled <- noise
+    Y <- noise_scaled
+  } else {
+    noise_scaled <- noise * sqrt(signal_power / (snr * noise_power))
+    Y <- signal + noise_scaled
+  }
   
   # Create output structure
   output <- list(
@@ -518,9 +524,14 @@ simulate_multi_subject <- function(n_subjects, V, T, K,
     # Scale noise based on SNR
     signal_power <- mean(signal_subj^2)
     noise_power <- mean(noise_subj^2)
-    noise_scaled <- noise_subj * sqrt(signal_power / (group_sim$params$snr * noise_power))
-    
-    Y_subj <- signal_subj + noise_scaled
+
+    if (group_sim$params$snr <= 0) {
+      noise_scaled <- noise_subj
+      Y_subj <- noise_scaled
+    } else {
+      noise_scaled <- noise_subj * sqrt(signal_power / (group_sim$params$snr * noise_power))
+      Y_subj <- signal_subj + noise_scaled
+    }
     
     subject_data[[subj]] <- list(
       Y = Y_subj,

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -135,10 +135,11 @@ test_that("Simulation handles extreme parameters", {
   
   # Zero SNR (pure noise)
   sim_zero_snr <- simulate_fmri_data(V = 100, T = 50, K = 3, snr = 0)
-  # Signal should be dominated by noise
+  # Signal should be dominated by noise and finite
   signal_var <- var(as.vector(sim_zero_snr$W %*% sim_zero_snr$X))
   noise_var <- var(as.vector(sim_zero_snr$noise))
   expect_true(noise_var > signal_var * 10)  # Noise much larger
+  expect_true(all(is.finite(sim_zero_snr$Y)))
 })
 
 test_that("Memory efficiency for large problems", {


### PR DESCRIPTION
## Summary
- avoid division by zero in `simulate_fmri_data` when SNR is zero or negative
- protect `simulate_multi_subject` from zero SNR
- test zero-SNR case for finite output

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a78430064832d9cedf3780759cc4c