### PR TITLE
Validate numeric data frames

### DIFF
--- a/R/data_structures.R
+++ b/R/data_structures.R
@@ -71,8 +71,14 @@ validate_fmri_input <- function(Y, expected_dims = NULL, check_finite = TRUE, ve
   # Handle data.frame that can be converted
   } else if (is.data.frame(Y)) {
     result$type <- "data.frame"
-    result$data <- as.matrix(Y)
-    if (verbose) message("Converted data.frame to matrix")
+    # ensure all columns are numeric before conversion
+    non_numeric_cols <- !vapply(Y, is.numeric, logical(1))
+    if (any(non_numeric_cols)) {
+      stop("data.frame contains non-numeric columns: ",
+           paste(names(Y)[non_numeric_cols], collapse = ", "))
+    }
+    result$data <- as.matrix(Y, mode = "numeric")
+    if (verbose) message("Converted data.frame to numeric matrix")
     
   } else {
     stop("Input must be a matrix, NeuroVec, or convertible data.frame")

--- a/tests/testthat/test-data_structures.R
+++ b/tests/testthat/test-data_structures.R
@@ -33,11 +33,20 @@ test_that("validate_fmri_input works with matrix input", {
 test_that("validate_fmri_input handles data.frame input", {
   # Create test data.frame
   Y_df <- as.data.frame(matrix(rnorm(100 * 50), nrow = 100, ncol = 50))
-  
+
   result <- validate_fmri_input(Y_df)
   expect_equal(result$type, "data.frame")
   expect_true(is.matrix(result$data))
+  expect_true(is.numeric(result$data))
   expect_equal(dim(result$data), c(100, 50))
+})
+
+test_that("validate_fmri_input errors with non-numeric data.frame", {
+  Y_bad <- data.frame(a = rnorm(10), b = letters[1:10])
+  expect_error(
+    validate_fmri_input(Y_bad),
+    "non-numeric columns"
+  )
 })
 
 test_that("extract_data_matrix handles different input types", {


### PR DESCRIPTION
## Summary
- ensure `validate_fmri_input` checks that data.frame inputs are numeric
- convert data.frame inputs with `as.matrix(..., mode = 'numeric')`
- test numeric data.frame handling and error on non-numeric columns

## Testing
- `which R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a7821230c832dad526d240be9b41a