### PR TITLE
Update extract_data_matrix to optionally force matrix output

### DIFF
--- a/R/data_structures.R
+++ b/R/data_structures.R
@@ -117,13 +117,18 @@ validate_fmri_input <- function(Y, expected_dims = NULL, check_finite = TRUE, ve
 #' @param obj NeuroVec, NeuroVol, or list of neuroimaging objects
 #' @param flatten_space Logical, whether to flatten spatial dimensions (default TRUE)
 #' @param preserve_attributes Logical, whether to preserve object attributes (default TRUE)
+#' @param force_matrix Logical, if TRUE always return a matrix by flattening
+#'   3-D data (default FALSE)
 #' 
 #' @return A list with components:
-#'   \item{data}{Numeric matrix}
+#'   \item{data}{Numeric matrix. If \code{flatten_space = FALSE} and
+#'     \code{force_matrix = FALSE} for 3-D input, a 3-D array is returned}
 #'   \item{metadata}{List of preserved metadata for reconstruction}
 #' 
 #' @export
-extract_data_matrix <- function(obj, flatten_space = TRUE, preserve_attributes = TRUE) {
+extract_data_matrix <- function(obj, flatten_space = TRUE,
+                                preserve_attributes = TRUE,
+                                force_matrix = FALSE) {
   metadata <- list()
   
   # NeuroVec (4D: space x time)
@@ -138,7 +143,7 @@ extract_data_matrix <- function(obj, flatten_space = TRUE, preserve_attributes =
     
   # NeuroVol (3D: space only)
   } else if (inherits(obj, "NeuroVol")) {
-    if (flatten_space) {
+    if (flatten_space || force_matrix) {
       data <- matrix(as.vector(obj), ncol = 1)
       metadata$original_dim <- dim(obj)
     } else {
@@ -168,7 +173,12 @@ extract_data_matrix <- function(obj, flatten_space = TRUE, preserve_attributes =
   } else {
     stop("Unsupported object type: ", paste(class(obj), collapse = ", "))
   }
-  
+
+  if (force_matrix && !is.matrix(data)) {
+    metadata$original_dim <- dim(data)
+    data <- matrix(as.vector(data), ncol = 1)
+  }
+
   list(data = data, metadata = metadata)
 }
 

--- a/tests/testthat/test-data_structures.R
+++ b/tests/testthat/test-data_structures.R
@@ -46,7 +46,12 @@ test_that("extract_data_matrix handles different input types", {
   result <- extract_data_matrix(mat)
   expect_equal(result$data, mat)
   expect_equal(result$metadata$class, "matrix")
-  
+
+  # With force_matrix flag (should be identical for matrix input)
+  result_force <- extract_data_matrix(mat, force_matrix = TRUE)
+  expect_equal(result_force$data, mat)
+  expect_equal(result_force$metadata$class, "matrix")
+
   # Test preserve_attributes = FALSE
   result2 <- extract_data_matrix(mat, preserve_attributes = FALSE)
   expect_equal(length(result2$metadata), 0)


### PR DESCRIPTION
## Summary
- add `force_matrix` argument to `extract_data_matrix`
- document optional array output when flattening is disabled
- test `force_matrix` option with matrix input

## Testing
- `N/A` *(R not available)*

------
https://chatgpt.com/codex/tasks/task_e_683a781d0d7c832da834aa0bc2d93481