### PR TITLE
Optimize dims calculation in visualization

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -57,10 +57,11 @@ plot_spatial_maps <- function(W, layout = NULL, zlim = NULL,
     zlim <- range(W_mat, na.rm = TRUE)
   }
   
+  # Compute matrix dimensions once
+  dims <- try_reshape_vector(V)
+
   # Plot each spatial map
   for (k in 1:K) {
-    # Try to reshape to approximate square
-    dims <- try_reshape_vector(V)
     map_matrix <- matrix(W_mat[, k], dims[1], dims[2])
     
     image(map_matrix, zlim = zlim, col = col, axes = FALSE,


### PR DESCRIPTION
## Summary
- compute the matrix dimensions once before plotting spatial maps

## Testing
- `R CMD build .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683a7883b914832d9fb4d9740383f596