### PR TITLE
Fix convergence text position for log scale

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -168,9 +168,12 @@ plot_convergence <- function(values, type = c("objective", "elbo"),
   }
   
   n_iter <- length(values)
-  
+
   # Set up plot
   ylab <- if (type == "objective") "Objective Value" else "ELBO"
+
+  label_y <- if (log_scale && all(values > 0))
+    log(mean(range(values))) else mean(range(values))
   
   if (log_scale && all(values > 0)) {
     plot(1:n_iter, log(values), type = "l", 
@@ -183,7 +186,7 @@ plot_convergence <- function(values, type = c("objective", "elbo"),
   # Highlight convergence point
   if (!is.null(highlight_converged) && highlight_converged <= n_iter) {
     abline(v = highlight_converged, col = "red", lty = 2)
-    text(highlight_converged, mean(range(values)), "Converged", 
+    text(highlight_converged, label_y, "Converged",
          col = "red", pos = 4)
   }
   


### PR DESCRIPTION
## Summary
- align convergence text with plot scale by computing `label_y`
- reference `label_y` when drawing the "Converged" marker

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a78834dec832db8b672a5268f5f2b