### PR TITLE
Fix NAMESPACE exports for simulation utilities

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -12,6 +12,8 @@ export(simulate_fmri_data)
 export(validate_fmri_input)
 export(extract_data_matrix)
 export(restore_spatial_structure)
+export(generate_event_design)
+export(simulate_multi_subject)
 
 # Visualization functions
 export(plot_spatial_maps)


### PR DESCRIPTION
## Summary
- add missing exports for `generate_event_design` and `simulate_multi_subject`

## Testing
- `Rscript -e 'roxygen2::roxygenize()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a7840b8f0832dabf8bef5573741ea