### PR TITLE
Implement voxel count validation in restore_spatial_structure

### DIFF
--- a/R/data_structures.R
+++ b/R/data_structures.R
@@ -203,6 +203,28 @@ restore_spatial_structure <- function(mat, reference, output_type = c("temporal"
     stop("Cannot extract spatial information from reference")
   }
   
+  # Determine expected voxel count from mask or space
+  expected_voxels <- NULL
+  if (!is.null(mask)) {
+    expected_voxels <- sum(mask)
+  } else {
+    space_dim <- try(neuroim2::dim(space_obj), silent = TRUE)
+    if (!inherits(space_dim, "try-error")) {
+      if (length(space_dim) > 3) {
+        expected_voxels <- prod(space_dim[1:3])
+      } else {
+        expected_voxels <- prod(space_dim)
+      }
+    }
+  }
+
+  if (!is.null(expected_voxels) && nrow(mat) != expected_voxels) {
+    stop(sprintf(
+      "Matrix has %d rows but spatial reference implies %d voxels",
+      nrow(mat), expected_voxels
+    ))
+  }
+
   # Restore based on output type
   if (output_type == "temporal") {
     # Time series data (V x T)

--- a/tests/testthat/test-data_structures.R
+++ b/tests/testthat/test-data_structures.R
@@ -123,3 +123,26 @@ test_that("create_output_structure works for both algorithms", {
   expect_true(!is.null(cbd_out$uncertainty))
   expect_true(!is.null(cbd_out$posterior_params))
 })
+
+test_that("restore_spatial_structure errors on dimension mismatch", {
+  skip_if_not_installed("neuroim2")
+
+  # Reference with space only
+  space_obj <- neuroim2::NeuroSpace(dim = c(2, 2, 2, 5))
+  mat_bad <- matrix(rnorm(10 * 5), nrow = 10, ncol = 5)
+  ref_space <- list(space = space_obj)
+
+  expect_error(
+    restore_spatial_structure(mat_bad, ref_space, output_type = "temporal"),
+    "10 rows.*8 voxels"
+  )
+
+  # Reference with mask
+  mask <- rep(TRUE, 5)
+  ref_mask <- list(space = space_obj, mask = mask)
+
+  expect_error(
+    restore_spatial_structure(mat_bad, ref_mask, output_type = "temporal"),
+    "10 rows.*5 voxels"
+  )
+})


### PR DESCRIPTION
## Summary
- validate spatial dimensions in `restore_spatial_structure`
- add regression tests for mismatched voxel counts

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a781b93b4832d848216def94464ed