### PR TITLE
Set probabilistic attribute for list restore

### DIFF
--- a/R/data_structures.R
+++ b/R/data_structures.R
@@ -228,8 +228,16 @@ restore_spatial_structure <- function(mat, reference, output_type = c("temporal"
   }
   
   # Add uncertainty information if probabilistic
-  if (probabilistic && !is.list(result)) {
-    attr(result, "probabilistic") <- TRUE
+  if (probabilistic) {
+    if (is.list(result)) {
+      result <- lapply(result, function(elem) {
+        attr(elem, "probabilistic") <- TRUE
+        elem
+      })
+      attr(result, "probabilistic") <- TRUE
+    } else {
+      attr(result, "probabilistic") <- TRUE
+    }
   }
   
   result

--- a/tests/testthat/test-data_structures.R
+++ b/tests/testthat/test-data_structures.R
@@ -123,3 +123,30 @@ test_that("create_output_structure works for both algorithms", {
   expect_true(!is.null(cbd_out$uncertainty))
   expect_true(!is.null(cbd_out$posterior_params))
 })
+
+test_that("restore_spatial_structure sets probabilistic attribute", {
+  skip_if_not_installed("neuroim2")
+
+  space <- neuroim2::NeuroSpace(dim = c(2, 2, 2), spacing = c(1, 1, 1))
+  ref <- neuroim2::NeuroVol(rnorm(8), space)
+
+  # Single spatial map
+  mat_single <- matrix(rnorm(8), nrow = 8, ncol = 1)
+  res_single <- restore_spatial_structure(mat_single, ref,
+                                          output_type = "spatial",
+                                          probabilistic = TRUE)
+  expect_true(!is.null(attr(res_single, "probabilistic")))
+
+  # Multiple spatial maps
+  mat_multi <- matrix(rnorm(16), nrow = 8, ncol = 2)
+  res_multi <- restore_spatial_structure(mat_multi, ref,
+                                         output_type = "spatial",
+                                         probabilistic = TRUE)
+  if (is.list(res_multi)) {
+    expect_true(!is.null(attr(res_multi, "probabilistic")))
+    expect_true(all(vapply(res_multi, function(x)
+      !is.null(attr(x, "probabilistic")), logical(1))))
+  } else {
+    expect_true(!is.null(attr(res_multi, "probabilistic")))
+  }
+})


### PR DESCRIPTION
## Summary
- add probabilistic attribute to each element when `restore_spatial_structure` returns a list
- test that attribute is present for single and multiple map cases

## Testing
- `R -q -e "devtools::test()"` *(fails: `R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a781922a4832d9a411cd6593d993e