### PR TITLE
Add forward declaration for transposed convolution helper

### DIFF
--- a/src/fista_gradient.cpp
+++ b/src/fista_gradient.cpp
@@ -4,6 +4,9 @@
 using namespace Rcpp;
 using namespace arma;
 
+// Forward declaration for transposed convolution helper
+arma::mat convolve_transpose_rcpp(const arma::mat& X, const arma::vec& hrf);
+
 //' Compute FISTA Gradient for CLD
 //' 
 //' Computes the gradient of the least squares term for FISTA optimization.


### PR DESCRIPTION
## Summary
- prevent implicit declaration warnings in `fista_gradient.cpp` by adding a prototype for `convolve_transpose_rcpp`

## Testing
- `g++ --version`
- *(fails: `R` not installed, so package build skipped)*

------
https://chatgpt.com/codex/tasks/task_e_683a7a8af840832db67312383d98f039