### PR TITLE
Remove unused parameter from estimate_lipschitz_rcpp

### DIFF
--- a/R/continuous_linear_decoder.R
+++ b/R/continuous_linear_decoder.R
@@ -521,8 +521,7 @@ ContinuousLinearDecoder <- R6::R6Class(
         # Use full W matrix
         estimate_lipschitz_rcpp(
           W = private$.W,
-          hrf_kernel = private$.hrf,
-          T = ncol(private$.Y)
+          hrf_kernel = private$.hrf
         )
       }
     },

--- a/src/fista_gradient.cpp
+++ b/src/fista_gradient.cpp
@@ -147,7 +147,6 @@ arma::mat convolve_transpose_rcpp(const arma::mat& X, const arma::vec& hrf) {
 //' 
 //' @param W Spatial maps matrix (V x K)
 //' @param hrf_kernel HRF kernel vector
-//' @param T Number of time points
 //' @param max_iter Maximum iterations for power method
 //' @param tol Convergence tolerance
 //' 
@@ -155,9 +154,8 @@ arma::mat convolve_transpose_rcpp(const arma::mat& X, const arma::vec& hrf) {
 //' 
 //' @export
 // [[Rcpp::export]]
-double estimate_lipschitz_rcpp(const arma::mat& W, 
+double estimate_lipschitz_rcpp(const arma::mat& W,
                                const arma::vec& hrf_kernel,
-                               int T,
                                int max_iter = 30,
                                double tol = 1e-6) {
   
@@ -167,9 +165,6 @@ double estimate_lipschitz_rcpp(const arma::mat& W,
   }
   if (hrf_kernel.is_empty()) {
     stop("HRF kernel cannot be empty");
-  }
-  if (T <= 0) {
-    stop("T must be positive");
   }
   
   // Compute W'W


### PR DESCRIPTION
## Summary
- drop the `T` argument from `estimate_lipschitz_rcpp`
- update CLD implementation to call the new function

## Testing
- `R -q -e "Rcpp::compileAttributes()"` *(fails: `R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a7a8b708c832db56204c19227761f