### PR TITLE
Optimize FISTA gradient

### DIFF
--- a/src/fista_gradient.cpp
+++ b/src/fista_gradient.cpp
@@ -14,16 +14,18 @@ using namespace arma;
 //' @param H_star_X Convolved states matrix (K x T)
 //' @param hrf_kernel HRF kernel vector
 //' @param precomputed_WtY Logical indicating if first argument is WtY
+//' @param WtW_precomp Optional pre-computed W'W matrix (K x K)
 //' 
 //' @return Gradient matrix (K x T)
 //' 
 //' @export
 // [[Rcpp::export]]
-arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY, 
+arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY,
                                       const arma::mat& W,
                                       const arma::mat& H_star_X,
                                       const arma::vec& hrf_kernel,
-                                      bool precomputed_WtY = false) {
+                                      bool precomputed_WtY = false,
+                                      const arma::mat& WtW_precomp = arma::mat()) {
   
   // Input validation
   if (Y_or_WtY.is_empty() || W.is_empty() || H_star_X.is_empty() || hrf_kernel.is_empty()) {
@@ -68,10 +70,15 @@ arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY,
     
   } else {
     // Efficient computation using pre-computed WtY
-    // WtW * H_star_X
-    arma::mat WtW = W.t() * W;
+    // Use provided WtW if available to avoid recomputation
+    arma::mat WtW;
+    if (WtW_precomp.is_empty()) {
+      WtW = W.t() * W;
+    } else {
+      WtW = WtW_precomp;
+    }
     arma::mat WtW_H_star_X = WtW * H_star_X;
-    
+
     // Grad_term = WtY - WtW * H_star_X
     Grad_term = Y_or_WtY - WtW_H_star_X;
   }

--- a/src/fista_solver.cpp
+++ b/src/fista_solver.cpp
@@ -5,11 +5,12 @@ using namespace Rcpp;
 using namespace arma;
 
 // Forward declarations of functions from other files
-arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY, 
+arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY,
                                       const arma::mat& W,
                                       const arma::mat& H_star_X,
                                       const arma::vec& hrf_kernel,
-                                      bool precomputed_WtY);
+                                      bool precomputed_WtY,
+                                      const arma::mat& WtW_precomp = arma::mat());
 
 arma::mat prox_tv_condat_rcpp(const arma::mat& X, double lambda_tv);
 
@@ -161,8 +162,8 @@ List fista_tv_rcpp(const arma::mat& WtY,
     
     // Compute gradient at Z
     arma::mat H_star_Z = convolve_rows_rcpp(Z, hrf_kernel);
-    arma::mat gradient = compute_gradient_fista_rcpp(WtY, W, H_star_Z, 
-                                                     hrf_kernel, true);
+    arma::mat gradient = compute_gradient_fista_rcpp(WtY, W, H_star_Z,
+                                                     hrf_kernel, true, WtW);
     
     // Gradient step
     arma::mat X_tilde = Z - step_size * gradient;


### PR DESCRIPTION
## Summary
- allow `compute_gradient_fista_rcpp` to take a precomputed WtW
- use this precomputed matrix from `fista_tv_rcpp`

## Testing
- `R CMD INSTALL .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a7a8bd334832d940c8448fe5c1c92