### PR TITLE
Remove unused arguments from Lipschitz lowrank

### DIFF
--- a/R/continuous_linear_decoder.R
+++ b/R/continuous_linear_decoder.R
@@ -514,8 +514,7 @@ ContinuousLinearDecoder <- R6::R6Class(
           U = private$.U_r,
           S = private$.S_r,
           V = private$.V_r,
-          hrf_kernel = private$.hrf,
-          T = ncol(private$.Y)
+          hrf_kernel = private$.hrf
         )
       } else {
         # Use full W matrix

--- a/src/lipschitz_lowrank.cpp
+++ b/src/lipschitz_lowrank.cpp
@@ -13,22 +13,27 @@ using namespace arma;
 //' @param S Singular values (length r)
 //' @param V Right singular vectors (K x r)
 //' @param hrf_kernel HRF kernel vector
-//' @param T Number of time points
-//' @param max_iter Maximum iterations for power method
-//' @param tol Convergence tolerance
 //' 
 //' @return Estimated Lipschitz constant
 //' 
 //' @export
 // [[Rcpp::export]]
-double estimate_lipschitz_lowrank_rcpp(const arma::mat& U, 
+double estimate_lipschitz_lowrank_rcpp(const arma::mat& U,
                                       const arma::vec& S,
                                       const arma::mat& V,
-                                      const arma::vec& hrf_kernel,
-                                      int T,
-                                      int max_iter = 30,
-                                      double tol = 1e-6) {
-  
+                                      const arma::vec& hrf_kernel) {
+
+  // Input validation
+  if (U.is_empty() || V.is_empty() || S.is_empty() || hrf_kernel.is_empty()) {
+    stop("Input matrices/vectors cannot be empty");
+  }
+
+  // Dimension checks
+  if (U.n_cols != S.n_elem || V.n_cols != S.n_elem) {
+    stop("Dimension mismatch: columns of U (%d) and V (%d) must match length of S (%d)",
+         U.n_cols, V.n_cols, S.n_elem);
+  }
+
   // For low-rank W = U * diag(S) * V'
   // W'W = V * diag(S^2) * V'
   // We need the largest eigenvalue of W'W

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -238,7 +238,7 @@ test_that("Low-rank operations are numerically stable", {
   
   # Test Lipschitz estimation
   hrf <- rep(1/10, 10)  # Simple normalized HRF
-  L <- estimate_lipschitz_lowrank_rcpp(U, S, V_mat, hrf, T = 100)
+  L <- estimate_lipschitz_lowrank_rcpp(U, S, V_mat, hrf)
   
   expect_true(is.finite(L))
   expect_gt(L, 0)


### PR DESCRIPTION
## Summary
- drop unused parameters from `estimate_lipschitz_lowrank_rcpp`
- add basic input validation to the low‑rank Lipschitz estimator
- update decoder call sites and tests

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683a7a9749fc832daf1b40ef16c6c9ca