### PR TITLE
Fix newline at EOF

### DIFF
--- a/src/fista_gradient.cpp
+++ b/src/fista_gradient.cpp
@@ -231,3 +231,4 @@ double estimate_lipschitz_rcpp(const arma::mat& W,
   // Return L = ||H||_2^2 * lambda_max(W'W)
   return hrf_norm_sq * lambda_new;
 }
+


### PR DESCRIPTION
## Summary
- add a newline at EOF for `src/fista_gradient.cpp`
- check other C++ sources for POSIX newline compliance

## Testing
- `R CMD build .` *(fails: R command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a7a8c98bc832d982a2b7027aeba4f