### PR TITLE
Add HRF spec validation and clarify docs

### DIFF
--- a/R/hrf_utils.R
+++ b/R/hrf_utils.R
@@ -10,7 +10,8 @@ NULL
 #' Setup HRF Kernel
 #'
 #' Accepts fmrireg HRF specifications or numeric vectors and normalizes
-#' them to unit energy for consistent convolution operations.
+#' them to unit energy for consistent convolution operations. Invalid HRF
+#' specifications will throw an error.
 #'
 #' @param spec HRF specification: can be a character string matching fmrireg
 #'   HRF types (e.g., "spmg1", "spmg2", "bspline"), a numeric vector, or
@@ -32,9 +33,17 @@ NULL
 #' hrf2 <- setup_hrf_kernel(custom_hrf)
 #' }
 setup_hrf_kernel <- function(spec = "spmg1", TR = 2, len = 32, normalize = TRUE) {
+  validate_hrf_spec(spec, context = "HRF specification")
+
   # Handle numeric vector input
   if (is.numeric(spec)) {
     hrf_vec <- spec
+    if (any(!is.finite(hrf_vec))) {
+      stop("HRF specification contains non-finite values")
+    }
+    if (sum(abs(hrf_vec)) == 0) {
+      stop("HRF specification is all zeros")
+    }
     if (normalize && sum(abs(hrf_vec)) > 0) {
       # Normalize to unit energy (sum of squares = 1)
       hrf_vec <- hrf_vec / sqrt(sum(hrf_vec^2))

--- a/tests/testthat/test-edge-cases.R
+++ b/tests/testthat/test-edge-cases.R
@@ -77,6 +77,10 @@ test_that("HRF utilities handle edge cases", {
   # Zero HRF
   hrf_zero <- rep(0, 16)
   expect_error(setup_hrf_kernel(hrf_zero), "is all zeros")
+
+  # Non-finite HRF
+  hrf_na <- c(0.2, NA, 0.3)
+  expect_error(setup_hrf_kernel(hrf_na), "non-finite values")
   
   # Single point HRF
   hrf_single <- 1


### PR DESCRIPTION
## Summary
- clarify that invalid HRF specs raise an error
- validate HRF spec at the start of `setup_hrf_kernel`
- guard against non-finite or zero vectors before normalization
- test non-finite numeric HRF vectors

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a7cd3911c832da946d007b1705f15