### PR TITLE
Remove unused variable from tv_proximal

### DIFF
--- a/src/tv_proximal.cpp
+++ b/src/tv_proximal.cpp
@@ -43,7 +43,6 @@ arma::vec prox_tv_condat_1d(const arma::vec& x, double lambda) {
   }
   
   // Condat's algorithm implementation
-  arma::vec y = x;
   arma::vec z(n);
   
   // Working variables


### PR DESCRIPTION
## Summary
- remove unused variable `y` from `tv_proximal.cpp`

## Testing
- `R CMD check --no-manual --as-cran .` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a7cc74c60832d9acb1e87396c3223