### PR TITLE
Add precomputed gradient API

### DIFF
--- a/R/continuous_linear_decoder.R
+++ b/R/continuous_linear_decoder.R
@@ -490,13 +490,12 @@ ContinuousLinearDecoder <- R6::R6Class(
     .compute_gradient = function(X_current) {
       # Call Rcpp implementation
       H_star_X <- convolve_rows_rcpp(X_current, private$.hrf)
-      
-      compute_gradient_fista_rcpp(
-        Y_or_WtY = private$.WtY,
-        W = private$.get_W(),
+
+      compute_gradient_fista_precomp_rcpp(
+        WtY = private$.WtY,
+        WtW = private$.WtW,
         H_star_X = H_star_X,
-        hrf_kernel = private$.hrf,
-        precomputed_WtY = TRUE
+        hrf_kernel = private$.hrf
       )
     },
     

--- a/src/fista_gradient.cpp
+++ b/src/fista_gradient.cpp
@@ -4,8 +4,12 @@
 using namespace Rcpp;
 using namespace arma;
 
-// Forward declaration for transposed convolution helper
+// Forward declarations for helper functions
 arma::mat convolve_transpose_rcpp(const arma::mat& X, const arma::vec& hrf);
+arma::mat compute_gradient_fista_precomp_rcpp(const arma::mat& WtY,
+                                              const arma::mat& WtW,
+                                              const arma::mat& H_star_X,
+                                              const arma::vec& hrf_kernel);
 
 //' Compute FISTA Gradient for CLD
 //' 
@@ -67,30 +71,66 @@ arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY,
     // Full computation: Grad_term = W'(Y - W * H_star_X)
     // Residual = Y - W * H_star_X
     arma::mat Residual = Y_or_WtY - W * H_star_X;
-    
+
     // Grad_term = W' * Residual
     Grad_term = W.t() * Residual;
-    
+
+    // Apply transposed convolution with time-reversed HRF
+    arma::mat Grad_L2 = convolve_transpose_rcpp(Grad_term, hrf_kernel);
+    return -Grad_L2;
+
   } else {
     // Efficient computation using pre-computed WtY
-    // Use provided WtW if available to avoid recomputation
     arma::mat WtW;
     if (WtW_precomp.is_empty()) {
       WtW = W.t() * W;
     } else {
       WtW = WtW_precomp;
     }
-    arma::mat WtW_H_star_X = WtW * H_star_X;
 
-    // Grad_term = WtY - WtW * H_star_X
-    Grad_term = Y_or_WtY - WtW_H_star_X;
+    // Delegate to the simplified pre-computed interface
+    return compute_gradient_fista_precomp_rcpp(Y_or_WtY, WtW,
+                                               H_star_X, hrf_kernel);
   }
-  
+}
+
+//' Compute FISTA Gradient with Pre-computed Terms
+//'
+//' Simplified version of \code{compute_gradient_fista_rcpp} that operates
+//' directly on pre-computed \eqn{W'Y} and \eqn{W'W} matrices.
+//'
+//' @param WtY Pre-computed \eqn{W'Y} matrix (K x T)
+//' @param WtW Pre-computed \eqn{W'W} matrix (K x K)
+//' @param H_star_X Convolved states matrix (K x T)
+//' @param hrf_kernel HRF kernel vector
+//'
+//' @return Gradient matrix (K x T)
+//'
+//' @export
+// [[Rcpp::export]]
+arma::mat compute_gradient_fista_precomp_rcpp(const arma::mat& WtY,
+                                              const arma::mat& WtW,
+                                              const arma::mat& H_star_X,
+                                              const arma::vec& hrf_kernel) {
+  // Input validation
+  if (WtY.is_empty() || WtW.is_empty() || H_star_X.is_empty() ||
+      hrf_kernel.is_empty()) {
+    stop("Input matrices/vectors cannot be empty");
+  }
+
+  if (WtY.n_rows != WtW.n_rows || WtW.n_rows != WtW.n_cols) {
+    stop("Dimension mismatch between WtY and WtW");
+  }
+  if (WtY.n_rows != H_star_X.n_rows || WtY.n_cols != H_star_X.n_cols) {
+    stop("Dimension mismatch between inputs");
+  }
+
+  // Gradient term in measurement space
+  arma::mat Grad_term = WtY - WtW * H_star_X;
+
   // Apply transposed convolution with time-reversed HRF
-  // This is the gradient with respect to X (before convolution)
   arma::mat Grad_L2 = convolve_transpose_rcpp(Grad_term, hrf_kernel);
-  
-  // Return negative gradient (since we minimize)
+
   return -Grad_L2;
 }
 

--- a/src/fista_solver.cpp
+++ b/src/fista_solver.cpp
@@ -12,6 +12,11 @@ arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY,
                                       bool precomputed_WtY,
                                       const arma::mat& WtW_precomp = arma::mat());
 
+arma::mat compute_gradient_fista_precomp_rcpp(const arma::mat& WtY,
+                                              const arma::mat& WtW,
+                                              const arma::mat& H_star_X,
+                                              const arma::vec& hrf_kernel);
+
 arma::mat prox_tv_condat_rcpp(const arma::mat& X, double lambda_tv);
 
 arma::mat convolve_rows_rcpp(const arma::mat& X, const arma::vec& hrf);
@@ -162,8 +167,9 @@ List fista_tv_rcpp(const arma::mat& WtY,
     
     // Compute gradient at Z
     arma::mat H_star_Z = convolve_rows_rcpp(Z, hrf_kernel);
-    arma::mat gradient = compute_gradient_fista_rcpp(WtY, W, H_star_Z,
-                                                     hrf_kernel, true, WtW);
+    arma::mat gradient = compute_gradient_fista_precomp_rcpp(WtY, WtW,
+                                                             H_star_Z,
+                                                             hrf_kernel);
     
     // Gradient step
     arma::mat X_tilde = Z - step_size * gradient;

--- a/tests/testthat/test-robustness.R
+++ b/tests/testthat/test-robustness.R
@@ -184,7 +184,7 @@ test_that("HRF convolution handles edge cases", {
 })
 
 test_that("Gradient computation is numerically stable", {
-  skip_if_not(exists("compute_gradient_fista_rcpp"), "Rcpp functions not compiled")
+  skip_if_not(exists("compute_gradient_fista_precomp_rcpp"), "Rcpp functions not compiled")
   
   # Test with extreme values
   W <- matrix(c(1e6, 1e-6, 1, 1e6, 1e-6, 1), nrow = 3, ncol = 2)
@@ -194,13 +194,15 @@ test_that("Gradient computation is numerically stable", {
   # Compute convolved X
   H_star_X <- stance:::convolve_rows_rcpp(X, hrf)
   
+  WtW <- t(W) %*% W
+  WtY <- WtW %*% H_star_X
+
   # This should not produce NaN or Inf
-  grad <- stance:::compute_gradient_fista_rcpp(
-    Y_or_WtY = t(W) %*% W %*% H_star_X,
-    W = W,
+  grad <- stance:::compute_gradient_fista_precomp_rcpp(
+    WtY = WtY,
+    WtW = WtW,
     H_star_X = H_star_X,
-    hrf_kernel = hrf,
-    precomputed_WtY = FALSE
+    hrf_kernel = hrf
   )
   
   expect_true(all(is.finite(grad)))


### PR DESCRIPTION
## Summary
- add `compute_gradient_fista_precomp_rcpp` for direct use with `WtY` and `WtW`
- use new API inside `compute_gradient_fista_rcpp`
- call the new gradient function from `fista_tv_rcpp` and R wrappers
- update robustness tests to use the precomputed-gradient version

## Testing
- `R CMD build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a7cc6f830832db455d49e09c56381