### PR TITLE
Add validation to prox_tv_dual

### DIFF
--- a/src/tv_proximal.cpp
+++ b/src/tv_proximal.cpp
@@ -192,11 +192,28 @@ double compute_tv_rcpp(const arma::mat& X) {
 //' 
 //' @keywords internal
 // [[Rcpp::export]]
-arma::vec prox_tv_dual(const arma::vec& x, double lambda, 
+arma::vec prox_tv_dual(const arma::vec& x, double lambda,
                        int max_iter = 100, double tol = 1e-8) {
+  if (x.is_empty()) {
+    stop("Input vector cannot be empty");
+  }
+
   int n = x.n_elem;
-  
-  if (n <= 1 || lambda <= 0) {
+
+  if (x.has_nan() || x.has_inf()) {
+    stop("Input vector contains NaN or Inf values");
+  }
+  if (!std::isfinite(lambda) || lambda < 0) {
+    stop("lambda must be non-negative and finite");
+  }
+  if (max_iter <= 0) {
+    stop("max_iter must be positive");
+  }
+  if (!std::isfinite(tol) || tol <= 0) {
+    stop("tol must be positive and finite");
+  }
+
+  if (n <= 1 || lambda == 0) {
     return x;
   }
   

--- a/tests/testthat/test-prox_tv_dual.R
+++ b/tests/testthat/test-prox_tv_dual.R
@@ -1,0 +1,36 @@
+skip_if_not(exists("prox_tv_dual"), "Rcpp functions not compiled")
+
+# Input validation tests for prox_tv_dual
+
+test_that("prox_tv_dual validates inputs", {
+  # Non-finite values in x
+  x_bad <- c(1, NA, 3)
+  expect_error(
+    stance:::prox_tv_dual(x_bad, lambda = 0.5),
+    "NaN or Inf" 
+  )
+
+  # Negative lambda
+  expect_error(
+    stance:::prox_tv_dual(c(1, 2, 3), lambda = -0.1),
+    "lambda must be non-negative and finite"
+  )
+
+  # Non-finite lambda
+  expect_error(
+    stance:::prox_tv_dual(c(1, 2, 3), lambda = Inf),
+    "lambda must be non-negative and finite"
+  )
+
+  # Invalid max_iter
+  expect_error(
+    stance:::prox_tv_dual(c(1, 2, 3), lambda = 0.1, max_iter = 0),
+    "max_iter must be positive"
+  )
+
+  # Invalid tolerance
+  expect_error(
+    stance:::prox_tv_dual(c(1, 2, 3), lambda = 0.1, tol = 0),
+    "tol must be positive and finite"
+  )
+})


### PR DESCRIPTION
## Summary
- validate arguments for `prox_tv_dual`
- add unit tests covering input errors for `prox_tv_dual`

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a7cbbdaf8832db106b0d25e0db59b