### PR TITLE
Simplify TV calculation

### DIFF
--- a/src/tv_proximal.cpp
+++ b/src/tv_proximal.cpp
@@ -167,15 +167,7 @@ double compute_tv_rcpp(const arma::mat& X) {
     stop("Input matrix contains NaN or Inf values");
   }
   
-  double tv = 0.0;
-  
-  for (int k = 0; k < X.n_rows; k++) {
-    for (int t = 1; t < X.n_cols; t++) {
-      tv += std::abs(X(k, t) - X(k, t-1));
-    }
-  }
-  
-  return tv;
+  return arma::accu(arma::abs(arma::diff(X, 1, 1)));
 }
 
 //' Alternative TV Proximal Operator using Dual Method

--- a/tests/testthat/test-compute_tv_rcpp.R
+++ b/tests/testthat/test-compute_tv_rcpp.R
@@ -1,0 +1,11 @@
+# Verify compute_tv_rcpp output
+
+test_that("compute_tv_rcpp matches manual calculation", {
+  skip_if_not(exists("compute_tv_rcpp"), "Rcpp functions not compiled")
+
+  X <- matrix(c(1, 3, 2, 5, 4, 6), nrow = 2, byrow = TRUE)
+  tv_manual <- sum(abs(X[, -1] - X[, -ncol(X)]))
+  tv_cpp <- stance:::compute_tv_rcpp(X)
+
+  expect_equal(tv_cpp, tv_manual)
+})


### PR DESCRIPTION
## Summary
- simplify `compute_tv_rcpp` by using `arma::diff` and `arma::accu`
- add a unit test that verifies the new implementation against a manual calculation

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a7cbc2590832dbbb63f5e4a2ba100