### PR TITLE
Fix duplicate operations in low-rank WtW function

### DIFF
--- a/src/lipschitz_lowrank.cpp
+++ b/src/lipschitz_lowrank.cpp
@@ -114,10 +114,6 @@ arma::mat compute_WtW_lowrank_rcpp(const arma::mat& V,
 
   // W'W = V * diag(S^2) * V'
 
-  // Scale columns of V by S
-  arma::mat V_scaled = V;
-  for (int i = 0; i < S.n_elem; i++)
-    V_scaled.col(i) *= S(i);
 
   // Input validation
   if (V.is_empty() || S.is_empty()) {


### PR DESCRIPTION
## Summary
- remove redundant scaling loop from `compute_WtW_lowrank_rcpp`

## Testing
- `R CMD build` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ad499b784832db3193878aa723412