### PR TITLE
Fix guard logic in prox_tv_dual

### DIFF
--- a/src/tv_proximal.cpp
+++ b/src/tv_proximal.cpp
@@ -191,10 +191,7 @@ arma::vec prox_tv_dual(const arma::vec& x, double lambda,
 
   int n = x.n_elem;
 
-  
-  if (n <= 2 || lambda <= 0) {
-
-
+  // Input validation
   if (x.has_nan() || x.has_inf()) {
     stop("Input vector contains NaN or Inf values");
   }
@@ -208,8 +205,7 @@ arma::vec prox_tv_dual(const arma::vec& x, double lambda,
     stop("tol must be positive and finite");
   }
 
-  if (n <= 1 || lambda == 0) {
-
+  if (n <= 2 || lambda == 0) {
     return x;
   }
   


### PR DESCRIPTION
## Summary
- ensure prox_tv_dual returns early for short inputs or zero lambda

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad6e81fe8832d9b1ca12b5fea4932