### PR TITLE
Implement S1-T01 infrastructure updates

### DIFF
--- a/tests/testthat/test-infrastructure.R
+++ b/tests/testthat/test-infrastructure.R
@@ -86,6 +86,7 @@ test_that("visualization functions handle various inputs", {
     plot_spatial_maps(W)
     plot_state_timecourse(X)
     plot_convergence(c(100, 90, 80, 75, 74, 73))
+    plot_convergence(seq(1, 0.1, length.out = 10), type = "elbo")
     dev.off()
   })
 })


### PR DESCRIPTION
## Summary
- extend `simulate_fmri_data()` to return Markov parameters
- add support for initial probabilities in `generate_markov_states`
- adjust multi-subject simulation and tests
- test ELBO plotting in visualization utils

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b25124420832da5015d5058f58a63