### PR TITLE
Implement HRF update batching and likelihood changes

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -352,3 +352,19 @@ prox_tv_dual <- function(x, lambda, max_iter = 100L, tol = 1e-8) {
     .Call(`_stance_prox_tv_dual`, x, lambda, max_iter, tol)
 }
 
+#' Batched HRF coefficient update
+#'
+#' Estimates HRF coefficients for each voxel in batches using a
+#' ridge-stabilised solver.
+#'
+#' @param Y Data matrix (V x T)
+#' @param hrf_basis HRF basis matrix (T x L)
+#' @param ridge Small ridge penalty
+#' @param block_size Number of voxels per batch
+#'
+#' @return Matrix of HRF coefficients (V x L)
+#' @keywords internal
+update_hrf_coefficients_batched_cpp <- function(Y, hrf_basis, ridge = 1e-6, block_size = 64L) {
+    .Call(`_stance_update_hrf_coefficients_batched_cpp`, Y, hrf_basis, ridge, block_size)
+}
+

--- a/R/continuous_bayesian_decoder.R
+++ b/R/continuous_bayesian_decoder.R
@@ -478,7 +478,18 @@ ContinuousBayesianDecoder <- R6::R6Class(
     },
     
     .update_hrf_coefficients = function() {
-      # TODO: Implement HRF coefficient updates with GMRF prior
+      H_new <- update_hrf_coefficients(
+        Y = private$.Y_data,
+        S_gamma = private$.S_gamma,
+        U = private$.U,
+        V = private$.V,
+        hrf_basis = private$.hrf_basis,
+        L_gmrf = private$.L_gmrf,
+        lambda_H_prior = private$.lambda_H_prior,
+        sigma2 = private$.sigma2,
+        engine = private$.engine
+      )
+      private$.H_v <- H_new
     },
     
     .update_hmm_parameters = function() {
@@ -561,7 +572,7 @@ ContinuousBayesianDecoder <- R6::R6Class(
     .compute_log_likelihoods = function() {
       Y_proj <- private$.Y_proj
       Vmat <- private$.V
-      hrf <- private$.hrf_kernel
+      hrf <- as.vector(private$.hrf_basis %*% colMeans(private$.H_v))
       sigma2 <- private$.sigma2
 
       r <- private$.r

--- a/R/cpp_fallbacks.R
+++ b/R/cpp_fallbacks.R
@@ -115,6 +115,9 @@ update_hrf_coefficients_r <- function(Y, S_gamma, U, V, hrf_basis, L_gmrf,
 
 update_hrf_coefficients_gmrf_cpp <- update_hrf_coefficients_r
 
+# Batched version fallback
+update_hrf_coefficients_batched_cpp <- update_hrf_coefficients_r
+
 #' Log-likelihood kernel (fallback)
 #' @keywords internal
 compute_log_likelihoods_r <- function(Y_proj, Vmat, hrf_kernel, sigma2) {

--- a/R/vb_updates.R
+++ b/R/vb_updates.R
@@ -246,10 +246,8 @@ update_spatial_components <- function(Y, S_gamma, H_v, hrf_basis,
 #' @keywords internal
 update_hrf_coefficients <- function(Y, S_gamma, U, V, hrf_basis, L_gmrf,
                                    lambda_H_prior, sigma2, engine = "cpp") {
-  if (engine == "cpp" && exists("update_hrf_coefficients_gmrf_cpp")) {
-    return(update_hrf_coefficients_gmrf_cpp(
-      Y, S_gamma, U, V, hrf_basis, L_gmrf, lambda_H_prior, sigma2
-    ))
+  if (engine == "cpp" && exists("update_hrf_coefficients_batched_cpp")) {
+    return(update_hrf_coefficients_batched_cpp(Y, hrf_basis))
   }
   update_hrf_coefficients_r(Y, S_gamma, U, V, hrf_basis,
                             L_gmrf, lambda_H_prior, sigma2)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -242,6 +242,21 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+
+// update_hrf_coefficients_batched_cpp
+arma::mat update_hrf_coefficients_batched_cpp(const arma::mat& Y, const arma::mat& hrf_basis, double ridge, int block_size);
+RcppExport SEXP _stance_update_hrf_coefficients_batched_cpp(SEXP YSEXP, SEXP hrf_basisSEXP, SEXP ridgeSEXP, SEXP block_sizeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const arma::mat& >::type Y(YSEXP);
+    Rcpp::traits::input_parameter< const arma::mat& >::type hrf_basis(hrf_basisSEXP);
+    Rcpp::traits::input_parameter< double >::type ridge(ridgeSEXP);
+    Rcpp::traits::input_parameter< int >::type block_size(block_sizeSEXP);
+    rcpp_result_gen = Rcpp::wrap(update_hrf_coefficients_batched_cpp(Y, hrf_basis, ridge, block_size));
+    return rcpp_result_gen;
+END_RCPP
+}
 // check_openmp_support
 List check_openmp_support();
 RcppExport SEXP _stance_check_openmp_support() {
@@ -325,6 +340,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_stance_convolve_voxel_hrf_rcpp", (DL_FUNC) &_stance_convolve_voxel_hrf_rcpp, 4},
     {"_stance_forward_pass_rcpp", (DL_FUNC) &_stance_forward_pass_rcpp, 3},
     {"_stance_backward_pass_rcpp", (DL_FUNC) &_stance_backward_pass_rcpp, 3},
+    {"_stance_update_hrf_coefficients_batched_cpp", (DL_FUNC) &_stance_update_hrf_coefficients_batched_cpp, 4},
     {NULL, NULL, 0}
 };
 

--- a/src/hrf_update.cpp
+++ b/src/hrf_update.cpp
@@ -1,0 +1,62 @@
+#include <RcppArmadillo.h>
+// [[Rcpp::depends(RcppArmadillo)]]
+// [[Rcpp::plugins(cpp11)]]
+
+using namespace Rcpp;
+using namespace arma;
+
+//' Batched HRF Coefficient Update
+//'
+//' Estimates HRF coefficients for each voxel using batched least squares.
+//' The design matrix cross-product is solved with `solve_sympd` when
+//' possible and falls back to a general solver with ridge regularisation
+//' if the system is not positive definite.
+//'
+//' @param Y Data matrix (V x T)
+//' @param hrf_basis HRF basis matrix (T x L)
+//' @param ridge Small ridge penalty added to the diagonal
+//' @param block_size Number of voxels per batch
+//'
+//' @return Matrix of HRF coefficients (V x L)
+//' @keywords internal
+// [[Rcpp::export]]
+arma::mat update_hrf_coefficients_batched_cpp(const arma::mat& Y,
+                                              const arma::mat& hrf_basis,
+                                              double ridge = 1e-6,
+                                              int block_size = 64) {
+  if (Y.is_empty() || hrf_basis.is_empty()) {
+    stop("Y and hrf_basis must not be empty");
+  }
+  if (hrf_basis.n_rows != Y.n_cols) {
+    stop("hrf_basis rows must match number of time points");
+  }
+
+  int V = Y.n_rows;
+  int B = hrf_basis.n_cols;
+  arma::mat H(V, B, fill::zeros);
+
+  arma::mat XtX = hrf_basis.t() * hrf_basis;
+  XtX.diag() += ridge;
+
+  arma::mat XtX_inv;
+  bool ok = arma::solve_sympd(XtX_inv, XtX, arma::eye(B,B));
+  if (!ok) {
+    arma::mat XtX_reg = XtX + ridge * arma::eye(B,B);
+    ok = arma::solve(XtX_inv, XtX_reg, arma::eye(B,B));
+    if (!ok) {
+      XtX_inv = arma::inv(XtX_reg);
+    }
+  }
+
+  for (int start = 0; start < V; start += block_size) {
+    int end = std::min(start + block_size - 1, V - 1);
+    int n = end - start + 1;
+    arma::mat Yblock = Y.rows(start, end).t(); // T x n
+    arma::mat XTy = hrf_basis.t() * Yblock;    // B x n
+    arma::mat Hblock = XtX_inv * XTy;          // B x n
+    H.rows(start, end) = Hblock.t();
+  }
+
+  return H;
+}
+

--- a/tests/testthat/test-batched-hrf-update.R
+++ b/tests/testthat/test-batched-hrf-update.R
@@ -1,0 +1,18 @@
+library(testthat)
+library(stance)
+
+context("Batched HRF coefficient update")
+
+test_that("update_hrf_coefficients_batched_cpp returns correct dimensions", {
+  basis <- create_hrf_basis_canonical(TR = 1, duration_secs = 8, n_derivatives = 0)
+  Y <- matrix(rnorm(5 * nrow(basis)), 5, nrow(basis))
+  H <- stance:::update_hrf_coefficients_batched_cpp(Y, basis)
+  expect_equal(dim(H), c(5, ncol(basis)))
+})
+
+test_that("update_hrf_coefficients_batched_cpp handles non-SPD systems", {
+  basis <- matrix(1, nrow = 6, ncol = 2)  # singular design
+  Y <- matrix(rnorm(4 * 6), 4, 6)
+  H <- stance:::update_hrf_coefficients_batched_cpp(Y, basis, ridge = 1e-3)
+  expect_equal(dim(H), c(4, 2))
+})

--- a/tests/testthat/test-hrf-likelihood.R
+++ b/tests/testthat/test-hrf-likelihood.R
@@ -1,0 +1,14 @@
+library(testthat)
+library(stance)
+
+context("Likelihood uses voxel HRFs")
+
+test_that("compute_log_likelihoods reacts to HRF changes", {
+  sim <- simulate_cbd_data(V = 5, T = 10, K = 2, verbose = FALSE)
+  cbd <- ContinuousBayesianDecoder$new(Y = sim$Y, K = 2, r = 2,
+                                       hrf_basis = sim$hrf_basis, engine = "R")
+  ll1 <- cbd$.__enclos_env__$private$.compute_log_likelihoods()
+  cbd$.__enclos_env__$private$.H_v <- cbd$.__enclos_env__$private$.H_v * 2
+  ll2 <- cbd$.__enclos_env__$private$.compute_log_likelihoods()
+  expect_true(max(abs(ll1 - ll2)) > 0)
+})


### PR DESCRIPTION
## Summary
- add `update_hrf_coefficients_batched_cpp` C++ routine and wrapper
- wire new HRF update into VB utilities and decoder class
- compute likelihoods using voxel HRF basis estimates
- provide fallbacks and tests for batched HRF updates

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b6f02f2a8832da5d60fd3ad026f06