### PR TITLE
Improve neighbor search in spatial utils

### DIFF
--- a/R/spatial_utils.R
+++ b/R/spatial_utils.R
@@ -44,16 +44,21 @@ get_spatial_neighbors <- function(mask, connectivity = 6) {
   neighbors <- vector("list", n_vox)
   dims <- dim(mask_arr)
 
+  # precompute linear indices for all voxel coordinates
+  coord_idx <- coords[,1] + (coords[,2]-1) * dims[1] +
+    (coords[,3]-1) * dims[1] * dims[2]
+
   for (i in seq_len(n_vox)) {
     nb_coords <- sweep(offsets, 2, coords[i, ], "+")
-    valid <- apply(nb_coords, 1, function(nc) {
-      all(nc > 0) && nc[1] <= dims[1] && nc[2] <= dims[2] && nc[3] <= dims[3] &&
-        mask_arr[nc[1], nc[2], nc[3]]
-    })
+    valid <- nb_coords[,1] > 0 & nb_coords[,1] <= dims[1] &
+             nb_coords[,2] > 0 & nb_coords[,2] <= dims[2] &
+             nb_coords[,3] > 0 & nb_coords[,3] <= dims[3] &
+             mask_arr[ nb_coords ]
     if (any(valid)) {
       val_coords <- nb_coords[valid, , drop = FALSE]
-      neighbors[[i]] <- match(apply(val_coords,1,paste,collapse=","),
-                              apply(coords,1,paste,collapse=","))
+      nb_idx <- val_coords[,1] + (val_coords[,2]-1) * dims[1] +
+        (val_coords[,3]-1) * dims[1] * dims[2]
+      neighbors[[i]] <- match(nb_idx, coord_idx)
       neighbors[[i]] <- neighbors[[i]][!is.na(neighbors[[i]])]
     } else {
       neighbors[[i]] <- integer(0)

--- a/tests/testthat/test-gmrf_utils.R
+++ b/tests/testthat/test-gmrf_utils.R
@@ -27,6 +27,8 @@ test_that("get_spatial_neighbors works with NeuroVol mask", {
   vol <- neuroim2::NeuroVol(mask_arr, neuroim2::NeuroSpace(c(2,2,1)))
   info <- get_spatial_neighbors(vol)
   expect_equal(length(info$neighbors), 4)
+  expect_equal(info$neighbors,
+               list(c(2L,3L), c(1L,4L), c(4L,1L), c(3L,2L)))
   L <- create_gmrf_laplacian(info$neighbors, length(info$neighbors))
   expect_true(Matrix::isSymmetric(L))
   expect_equal(Matrix::rowSums(L), rep(0, 4))
@@ -37,6 +39,7 @@ test_that("get_spatial_neighbors handles logical mask", {
   info <- get_spatial_neighbors(mask)
   L <- create_gmrf_laplacian(info$neighbors, length(info$neighbors))
   expect_equal(dim(L), c(2,2))
+  expect_equal(info$neighbors, list(2L,1L))
   expect_true(Matrix::isSymmetric(L))
   expect_equal(Matrix::rowSums(L), rep(0, 2))
 })


### PR DESCRIPTION
## Summary
- precompute linear indices for voxels in `get_spatial_neighbors`
- vectorize neighbor validity checks and matching logic
- check expected neighbor lists in unit tests

## Testing
- `R CMD check` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ba237fb64832d99a9c3287d3d0d60