### PR TITLE
Use matrixStats for state stacking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     ggplot2,
     dplyr,
     magrittr,
+    matrixStats,
     MASS,
     stats,
     methods

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -134,7 +134,7 @@ plot_state_timecourse <- function(X, type = c("line", "heatmap", "stacked"),
     X_prop[is.nan(X_prop)] <- 0
     
     # Cumulative sums for stacking
-    X_cumsum <- apply(X_prop, 2, cumsum)
+    X_cumsum <- matrixStats::colCumsums(X_prop)
     
     plot(time_axis, rep(1, T), type = "n", ylim = c(0, 1),
          xlab = xlab, ylab = "Proportion", main = main, ...)


### PR DESCRIPTION
## Summary
- use `matrixStats::colCumsums` when stacking state timecourses
- import matrixStats in DESCRIPTION

## Testing
- `R CMD build .` *(fails: `bash: R: command not found`)*
- `R CMD check stance_*.tar.gz` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ba23d2848832d815646ba533a1306