### PR TITLE
Use Rcpp row convolution

### DIFF
--- a/R/hrf_utils.R
+++ b/R/hrf_utils.R
@@ -154,12 +154,8 @@ convolve_with_hrf <- function(X, hrf, use_fft_threshold = 256, method = "auto") 
         result[i, ] <- convolve_fft(X[i, ], hrf, H_fft = H_fft, n_fft = n_fft)
       }
     } else {
-      # Direct convolution
-      result <- matrix(0, n_signals, n_time)
-      for (i in seq_len(n_signals)) {
-        conv_out <- stats::convolve(X[i, ], rev(hrf), type = "open")
-        result[i, ] <- conv_out[seq_len(n_time)]
-      }
+      # Direct convolution via Rcpp implementation
+      result <- convolve_rows_rcpp(X, hrf)
     }
   } else if (is.matrix(hrf)) {
     # Multiple HRFs case (for future CBD support)

--- a/tests/testthat/test-robustness.R
+++ b/tests/testthat/test-robustness.R
@@ -185,6 +185,14 @@ test_that("HRF convolution handles edge cases", {
   expect_equal(dim(result_multi), dim(X))
 })
 
+test_that("convolve_with_hrf matches C++ implementation for small matrices", {
+  X <- matrix(rnorm(6 * 10), nrow = 6)
+  hrf <- c(0.2, 0.5, 0.3)
+  r_result <- convolve_with_hrf(X, hrf, method = "direct")
+  cpp_result <- stance:::convolve_rows_rcpp(X, hrf)
+  expect_equal(r_result, cpp_result)
+})
+
 test_that("Gradient computation is numerically stable", {
   skip_if_not(exists("compute_gradient_fista_precomp_rcpp"), "Rcpp functions not compiled")
   


### PR DESCRIPTION
## Summary
- speed up single HRF convolution by delegating to Rcpp
- add regression test for Rcpp convolution

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ba73dbb9c832d9152fa52b02eb6ae