### PR TITLE
Vectorize AR1 filtering in noise simulation

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -516,10 +516,10 @@ generate_structured_noise <- function(V, T, dims = NULL) {
   
   # Add temporal autocorrelation (AR1)
   ar_coef <- 0.3
-  for (v in 1:V) {
-    noise[v, ] <- stats::filter(noise[v, ], filter = ar_coef, 
-                                method = "recursive")
-  }
+  # Vectorized AR1 filter across voxels
+  noise <- t(apply(noise, 1, function(row) {
+    as.numeric(stats::filter(row, filter = ar_coef, method = "recursive"))
+  }))
   
   # Add spatial correlation if dimensions provided
   if (!is.null(dims) && prod(dims) == V) {


### PR DESCRIPTION
## Summary
- remove per-voxel loop when adding temporal autocorrelation
- use `apply()` to filter all voxels in one step

## Testing
- `R CMD check` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ba7453f18832d97b476c885fc6635