### PR TITLE
Add Rcpp spatial neighbor utility

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -396,3 +396,23 @@ update_hrf_coefficients_batched_cpp <- function(Y, hrf_basis, ridge = 1e-6, bloc
     .Call(`_stance_update_hrf_coefficients_batched_cpp`, Y, hrf_basis, ridge, block_size)
 }
 
+#' Internal spatial neighbor computation
+#'
+#' Computes voxel neighbors and Laplacian entries for a 3D mask.
+#'
+#' @param mask Logical vector representing the mask
+#' @param dims Integer vector of length 3
+#' @param connectivity Connectivity (6, 18 or 26)
+#' @keywords internal
+spatial_neighbors_cpp <- function(mask, dims, connectivity = 6L) {
+    .Call(`_stance_spatial_neighbors_cpp`, mask, dims, connectivity)
+}
+
+#' Build Laplacian from neighbor list
+#'
+#' @param neighbors List of integer vectors
+#' @keywords internal
+laplacian_from_neighbors_cpp <- function(neighbors) {
+    .Call(`_stance_laplacian_from_neighbors_cpp`, neighbors)
+}
+

--- a/R/spatial_utils.R
+++ b/R/spatial_utils.R
@@ -26,46 +26,21 @@ NULL
 #' @export
 get_spatial_neighbors <- function(mask, connectivity = 6) {
   if (inherits(mask, "NeuroVol")) {
-    coords <- neuroim2::coords(mask)
     mask_arr <- as.logical(mask > 0)
   } else {
     mask_arr <- as.logical(mask)
-    coords <- which(mask_arr, arr.ind = TRUE)
   }
 
-  offsets <- switch(as.character(connectivity),
-    "6"  = rbind(c(-1,0,0), c(1,0,0), c(0,-1,0), c(0,1,0), c(0,0,-1), c(0,0,1)),
-    "18" = as.matrix(expand.grid(-1:1,-1:1,-1:1))[-14,],
-    "26" = as.matrix(expand.grid(-1:1,-1:1,-1:1))[-14,],
-    stop("Unsupported connectivity: ", connectivity)
-  )
-
-  n_vox <- nrow(coords)
-  neighbors <- vector("list", n_vox)
   dims <- dim(mask_arr)
+  res <- spatial_neighbors_cpp(as.vector(mask_arr), dims, as.integer(connectivity))
 
-  # precompute linear indices for all voxel coordinates
-  coord_idx <- coords[,1] + (coords[,2]-1) * dims[1] +
-    (coords[,3]-1) * dims[1] * dims[2]
-
-  for (i in seq_len(n_vox)) {
-    nb_coords <- sweep(offsets, 2, coords[i, ], "+")
-    valid <- nb_coords[,1] > 0 & nb_coords[,1] <= dims[1] &
-             nb_coords[,2] > 0 & nb_coords[,2] <= dims[2] &
-             nb_coords[,3] > 0 & nb_coords[,3] <= dims[3] &
-             mask_arr[ nb_coords ]
-    if (any(valid)) {
-      val_coords <- nb_coords[valid, , drop = FALSE]
-      nb_idx <- val_coords[,1] + (val_coords[,2]-1) * dims[1] +
-        (val_coords[,3]-1) * dims[1] * dims[2]
-      neighbors[[i]] <- match(nb_idx, coord_idx)
-      neighbors[[i]] <- neighbors[[i]][!is.na(neighbors[[i]])]
-    } else {
-      neighbors[[i]] <- integer(0)
-    }
+  coords <- if (inherits(mask, "NeuroVol")) {
+    neuroim2::coords(mask)
+  } else {
+    res$coords
   }
 
-  list(neighbors = neighbors, coords = coords)
+  list(neighbors = res$neighbors, coords = coords)
 }
 
 #' Create a sparse GMRF Laplacian
@@ -79,23 +54,7 @@ get_spatial_neighbors <- function(mask, connectivity = 6) {
 #' @return A `dgCMatrix` sparse Laplacian.
 #' @export
 create_gmrf_laplacian <- function(neighbors, n_voxels) {
-  i <- integer(0)
-  j <- integer(0)
-  x <- numeric(0)
-
-  for (v in seq_len(n_voxels)) {
-    nb <- neighbors[[v]]
-    n_nb <- length(nb)
-    if (n_nb > 0) {
-      i <- c(i, v)
-      j <- c(j, v)
-      x <- c(x, n_nb)
-
-      i <- c(i, rep(v, n_nb))
-      j <- c(j, nb)
-      x <- c(x, rep(-1, n_nb))
-    }
-  }
-
-  Matrix::sparseMatrix(i = i, j = j, x = x, dims = c(n_voxels, n_voxels))
+  lap <- laplacian_from_neighbors_cpp(neighbors)
+  Matrix::sparseMatrix(i = lap$i, j = lap$j, x = lap$x,
+                       dims = c(n_voxels, n_voxels))
 }

--- a/inst/benchmarks/spatial_neighbors_benchmark.R
+++ b/inst/benchmarks/spatial_neighbors_benchmark.R
@@ -1,0 +1,95 @@
+library(stance)
+library(microbenchmark)
+
+# legacy implementations preserved for benchmarking
+get_spatial_neighbors_loop <- function(mask, connectivity = 6) {
+  if (inherits(mask, "NeuroVol")) {
+    coords <- neuroim2::coords(mask)
+    mask_arr <- as.logical(mask > 0)
+  } else {
+    mask_arr <- as.logical(mask)
+    coords <- which(mask_arr, arr.ind = TRUE)
+  }
+
+  offsets <- switch(as.character(connectivity),
+    "6"  = rbind(c(-1,0,0), c(1,0,0), c(0,-1,0), c(0,1,0), c(0,0,-1), c(0,0,1)),
+    "18" = as.matrix(expand.grid(-1:1,-1:1,-1:1))[-14,],
+    "26" = as.matrix(expand.grid(-1:1,-1:1,-1:1))[-14,],
+    stop("Unsupported connectivity: ", connectivity)
+  )
+
+  n_vox <- nrow(coords)
+  neighbors <- vector("list", n_vox)
+  dims <- dim(mask_arr)
+
+  coord_idx <- coords[,1] + (coords[,2]-1) * dims[1] +
+    (coords[,3]-1) * dims[1] * dims[2]
+
+  for (i in seq_len(n_vox)) {
+    nb_coords <- sweep(offsets, 2, coords[i, ], "+")
+    valid <- nb_coords[,1] > 0 & nb_coords[,1] <= dims[1] &
+             nb_coords[,2] > 0 & nb_coords[,2] <= dims[2] &
+             nb_coords[,3] > 0 & nb_coords[,3] <= dims[3] &
+             mask_arr[ nb_coords ]
+    if (any(valid)) {
+      val_coords <- nb_coords[valid, , drop = FALSE]
+      nb_idx <- val_coords[,1] + (val_coords[,2]-1) * dims[1] +
+        (val_coords[,3]-1) * dims[1] * dims[2]
+      neighbors[[i]] <- match(nb_idx, coord_idx)
+      neighbors[[i]] <- neighbors[[i]][!is.na(neighbors[[i]])]
+    } else {
+      neighbors[[i]] <- integer(0)
+    }
+  }
+
+  list(neighbors = neighbors, coords = coords)
+}
+
+create_gmrf_laplacian_loop <- function(neighbors, n_voxels) {
+  i <- integer(0)
+  j <- integer(0)
+  x <- numeric(0)
+
+  for (v in seq_len(n_voxels)) {
+    nb <- neighbors[[v]]
+    n_nb <- length(nb)
+    if (n_nb > 0) {
+      i <- c(i, v)
+      j <- c(j, v)
+      x <- c(x, n_nb)
+
+      i <- c(i, rep(v, n_nb))
+      j <- c(j, nb)
+      x <- c(x, rep(-1, n_nb))
+    }
+  }
+
+  Matrix::sparseMatrix(i = i, j = j, x = x, dims = c(n_voxels, n_voxels))
+}
+
+benchmark_spatial_neighbors <- function(size = c(30,30,30), connectivity = 6) {
+  mask <- array(TRUE, dim = size)
+
+  time_loop <- microbenchmark(
+    {
+      info <- get_spatial_neighbors_loop(mask, connectivity)
+      create_gmrf_laplacian_loop(info$neighbors, length(info$neighbors))
+    }, times = 5
+  )
+
+  time_cpp <- microbenchmark(
+    {
+      info <- get_spatial_neighbors(mask, connectivity)
+      create_gmrf_laplacian(info$neighbors, length(info$neighbors))
+    }, times = 5
+  )
+
+  data.frame(
+    method = c("loop", "cpp"),
+    median_ms = c(median(time_loop$time) / 1e6,
+                  median(time_cpp$time) / 1e6)
+  )
+}
+
+# Example:
+# print(benchmark_spatial_neighbors())

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -348,6 +348,32 @@ BEGIN_RCPP
 END_RCPP
 }
 
+// spatial_neighbors_cpp
+List spatial_neighbors_cpp(const LogicalVector& mask, const IntegerVector& dims, int connectivity);
+RcppExport SEXP _stance_spatial_neighbors_cpp(SEXP maskSEXP, SEXP dimsSEXP, SEXP connectivitySEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const LogicalVector& >::type mask(maskSEXP);
+    Rcpp::traits::input_parameter< const IntegerVector& >::type dims(dimsSEXP);
+    Rcpp::traits::input_parameter< int >::type connectivity(connectivitySEXP);
+    rcpp_result_gen = Rcpp::wrap(spatial_neighbors_cpp(mask, dims, connectivity));
+    return rcpp_result_gen;
+END_RCPP
+}
+
+// laplacian_from_neighbors_cpp
+List laplacian_from_neighbors_cpp(List neighbors);
+RcppExport SEXP _stance_laplacian_from_neighbors_cpp(SEXP neighborsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< List >::type neighbors(neighborsSEXP);
+    rcpp_result_gen = Rcpp::wrap(laplacian_from_neighbors_cpp(neighbors));
+    return rcpp_result_gen;
+END_RCPP
+}
+
 static const R_CallMethodDef CallEntries[] = {
     {"_stance_compute_gradient_fista_rcpp", (DL_FUNC) &_stance_compute_gradient_fista_rcpp, 6},
     {"_stance_compute_gradient_fista_precomp_rcpp", (DL_FUNC) &_stance_compute_gradient_fista_precomp_rcpp, 4},
@@ -368,6 +394,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_stance_prox_tv_condat_rcpp", (DL_FUNC) &_stance_prox_tv_condat_rcpp, 3},
     {"_stance_compute_tv_rcpp", (DL_FUNC) &_stance_compute_tv_rcpp, 1},
     {"_stance_prox_tv_dual", (DL_FUNC) &_stance_prox_tv_dual, 4},
+    {"_stance_spatial_neighbors_cpp", (DL_FUNC) &_stance_spatial_neighbors_cpp, 3},
+    {"_stance_laplacian_from_neighbors_cpp", (DL_FUNC) &_stance_laplacian_from_neighbors_cpp, 1},
     {"_stance_convolve_voxel_hrf_rcpp", (DL_FUNC) &_stance_convolve_voxel_hrf_rcpp, 4},
     {"_stance_convolve_voxel_hrf_fft_rcpp", (DL_FUNC) &_stance_convolve_voxel_hrf_fft_rcpp, 3},
     {"_stance_forward_pass_rcpp", (DL_FUNC) &_stance_forward_pass_rcpp, 3},

--- a/src/spatial_neighbors.cpp
+++ b/src/spatial_neighbors.cpp
@@ -1,0 +1,146 @@
+#include <Rcpp.h>
+// [[Rcpp::plugins(cpp11)]]
+
+using namespace Rcpp;
+
+// helper to generate offsets based on connectivity
+static std::vector< std::array<int,3> >
+make_offsets(int connectivity) {
+  std::vector< std::array<int,3> > offs;
+  for (int dz = -1; dz <= 1; ++dz) {
+    for (int dy = -1; dy <= 1; ++dy) {
+      for (int dx = -1; dx <= 1; ++dx) {
+        if (dx == 0 && dy == 0 && dz == 0) continue;
+        int manhattan = std::abs(dx) + std::abs(dy) + std::abs(dz);
+        if (connectivity == 6) {
+          if (manhattan == 1) offs.push_back({{dx,dy,dz}});
+        } else if (connectivity == 18) {
+          if (manhattan <= 2) offs.push_back({{dx,dy,dz}});
+        } else if (connectivity == 26) {
+          offs.push_back({{dx,dy,dz}});
+        } else {
+          stop("Unsupported connectivity");
+        }
+      }
+    }
+  }
+  return offs;
+}
+
+// [[Rcpp::export]]
+List spatial_neighbors_cpp(const LogicalVector& mask,
+                           const IntegerVector& dims,
+                           int connectivity) {
+  if (dims.size() != 3)
+    stop("dims must have length 3");
+  int nx = dims[0];
+  int ny = dims[1];
+  int nz = dims[2];
+  int total = nx * ny * nz;
+  if (mask.size() != total)
+    stop("mask length does not match dims");
+
+  // mapping from linear index to voxel id
+  std::vector<int> mapping(total, 0);
+  std::vector< std::array<int,3> > coords_vec;
+  coords_vec.reserve(total);
+
+  for (int z = 0; z < nz; ++z) {
+    for (int y = 0; y < ny; ++y) {
+      for (int x = 0; x < nx; ++x) {
+        int lin = x + y*nx + z*nx*ny;
+        if (mask[lin]) {
+          mapping[lin] = coords_vec.size() + 1; // 1-based
+          coords_vec.push_back({{x+1,y+1,z+1}});
+        }
+      }
+    }
+  }
+
+  int n_vox = coords_vec.size();
+  List neighbors(n_vox);
+  std::vector<int> i_vec;
+  std::vector<int> j_vec;
+  std::vector<double> x_vec;
+  i_vec.reserve(n_vox * 7);
+  j_vec.reserve(n_vox * 7);
+  x_vec.reserve(n_vox * 7);
+
+  std::vector< std::array<int,3> > offs = make_offsets(connectivity);
+
+  for (int v = 0; v < n_vox; ++v) {
+    int x = coords_vec[v][0];
+    int y = coords_vec[v][1];
+    int z = coords_vec[v][2];
+    std::vector<int> nb_local;
+    nb_local.reserve(offs.size());
+    for (auto& o : offs) {
+      int nxp = x + o[0];
+      int nyp = y + o[1];
+      int nzp = z + o[2];
+      if (nxp >= 1 && nxp <= nx &&
+          nyp >= 1 && nyp <= ny &&
+          nzp >= 1 && nzp <= nz) {
+        int lin = (nxp-1) + (nyp-1)*nx + (nzp-1)*nx*ny;
+        int nb_idx = mapping[lin];
+        if (nb_idx > 0) {
+          nb_local.push_back(nb_idx);
+        }
+      }
+    }
+    IntegerVector nb(nb_local.begin(), nb_local.end());
+    neighbors[v] = nb;
+
+    int degree = nb_local.size();
+    i_vec.push_back(v + 1);
+    j_vec.push_back(v + 1);
+    x_vec.push_back(static_cast<double>(degree));
+    for (int nb_idx : nb_local) {
+      i_vec.push_back(v + 1);
+      j_vec.push_back(nb_idx);
+      x_vec.push_back(-1.0);
+    }
+  }
+
+  IntegerMatrix coords_out(n_vox, 3);
+  for (int v = 0; v < n_vox; ++v) {
+    coords_out(v,0) = coords_vec[v][0];
+    coords_out(v,1) = coords_vec[v][1];
+    coords_out(v,2) = coords_vec[v][2];
+  }
+
+  IntegerVector I(i_vec.begin(), i_vec.end());
+  IntegerVector J(j_vec.begin(), j_vec.end());
+  NumericVector X(x_vec.begin(), x_vec.end());
+
+  return List::create(Named("neighbors") = neighbors,
+                      Named("coords") = coords_out,
+                      Named("i") = I,
+                      Named("j") = J,
+                      Named("x") = X);
+}
+
+// [[Rcpp::export]]
+List laplacian_from_neighbors_cpp(List neighbors) {
+  int n_voxels = neighbors.size();
+  std::vector<int> i_vec;
+  std::vector<int> j_vec;
+  std::vector<double> x_vec;
+  for (int v = 0; v < n_voxels; ++v) {
+    IntegerVector nb = neighbors[v];
+    int degree = nb.size();
+    i_vec.push_back(v + 1);
+    j_vec.push_back(v + 1);
+    x_vec.push_back(static_cast<double>(degree));
+    for (int k = 0; k < degree; ++k) {
+      i_vec.push_back(v + 1);
+      j_vec.push_back(nb[k]);
+      x_vec.push_back(-1.0);
+    }
+  }
+  IntegerVector I(i_vec.begin(), i_vec.end());
+  IntegerVector J(j_vec.begin(), j_vec.end());
+  NumericVector X(x_vec.begin(), x_vec.end());
+  return List::create(Named("i")=I, Named("j")=J, Named("x")=X);
+}
+


### PR DESCRIPTION
## Summary
- implement `spatial_neighbors_cpp` and `laplacian_from_neighbors_cpp` in new `src/spatial_neighbors.cpp`
- generate R wrappers in `R/RcppExports.R` and registration in `src/RcppExports.cpp`
- refactor `get_spatial_neighbors()` and `create_gmrf_laplacian()` to use the Rcpp routines
- add `inst/benchmarks/spatial_neighbors_benchmark.R` comparing new C++ path with previous R loops

## Testing
- `R CMD build .` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ba74d518c832d95e30b36c8a8b514