### PR TITLE
Refactor roughness calculation

### DIFF
--- a/R/gmrf_utils.R
+++ b/R/gmrf_utils.R
@@ -96,11 +96,16 @@ create_chain_laplacian <- function(n_voxels) {
 #' @export
 compute_roughness <- function(H, L) {
   if (!is.matrix(H)) H <- as.matrix(H)
-  total <- 0
-  for (b in seq_len(ncol(H))) {
-    h <- H[, b]
-    total <- total + as.numeric(t(h) %*% L %*% h)
+
+  LH <- L %*% H
+  use_ms <- requireNamespace("matrixStats", quietly = TRUE)
+
+  rough_vals <- if (use_ms) {
+    matrixStats::colSums2(LH * H)
+  } else {
+    colSums(LH * H)
   }
-  total / ncol(H)
+
+  mean(rough_vals)
 }
 

--- a/tests/testthat/test-compute_roughness.R
+++ b/tests/testthat/test-compute_roughness.R
@@ -1,0 +1,22 @@
+library(testthat)
+library(stance)
+
+set.seed(123)
+H <- matrix(rnorm(20), nrow = 5, ncol = 4)
+L <- diag(5) - matrix(1/5, 5, 5)
+
+compute_ref <- function(H, L) {
+  total <- 0
+  for (b in seq_len(ncol(H))) {
+    h <- H[, b]
+    total <- total + as.numeric(t(h) %*% L %*% h)
+  }
+  total / ncol(H)
+}
+
+ref_val <- compute_ref(H, L)
+fast_val <- compute_roughness(H, L)
+
+test_that("compute_roughness matches loop implementation", {
+  expect_equal(fast_val, ref_val)
+})


### PR DESCRIPTION
## Summary
- refactor `compute_roughness()` to use matrix operations
- add optional fast path using `matrixStats`
- add explicit regression test for `compute_roughness`

## Testing
- `R -q -e "testthat::test_package('stance')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ba75305f8832d8e13f08f8fcae696