### PR TITLE
Add R E-step and cross-engine test

### DIFF
--- a/R/continuous_bayesian_decoder.R
+++ b/R/continuous_bayesian_decoder.R
@@ -516,10 +516,18 @@ ContinuousBayesianDecoder <- R6::R6Class(
       }
     },
     
-    # E-step R implementation (placeholder)
+    # E-step R implementation
+    #
+    # Mirrors the C++ path by first computing the state-specific
+    # log-likelihoods and then running the forward–backward algorithm
+    # using the currently selected R engine helpers.  The updated
+    # posteriors are stored in `.S_gamma` and `.S_xi`.
     .e_step_r = function() {
-      # TODO: Implement R version for comparison
-      stop("R implementation not yet available")
+      log_lik <- private$.compute_log_likelihoods()
+      fb <- private$.forward_backward(log_lik)
+      private$.S_gamma <- fb$gamma
+      private$.S_xi <- fb$xi
+      invisible(NULL)
     },
     
     # M-step implementation

--- a/tests/testthat/test-e_step.R
+++ b/tests/testthat/test-e_step.R
@@ -1,0 +1,22 @@
+library(testthat)
+library(stance)
+
+# Ensure e_step behaves the same under both engines
+
+test_that("e_step produces consistent posteriors across engines", {
+  set.seed(101)
+  sim <- simulate_fmri_data(V = 6, T = 10, K = 2, algorithm = "CBD", verbose = FALSE)
+
+  cbd_cpp <- ContinuousBayesianDecoder$new(Y = sim$Y, K = 2, r = 2, engine = "cpp")
+  cbd_cpp$.__enclos_env__$private$.e_step()
+  gamma_cpp <- cbd_cpp$.__enclos_env__$private$.S_gamma
+  xi_cpp <- cbd_cpp$.__enclos_env__$private$.S_xi
+
+  cbd_r <- ContinuousBayesianDecoder$new(Y = sim$Y, K = 2, r = 2, engine = "R")
+  cbd_r$.__enclos_env__$private$.e_step()
+  gamma_r <- cbd_r$.__enclos_env__$private$.S_gamma
+  xi_r <- cbd_r$.__enclos_env__$private$.S_xi
+
+  expect_equal(gamma_cpp, gamma_r, tolerance = 1e-6)
+  expect_equal(xi_cpp, xi_r, tolerance = 1e-6)
+})


### PR DESCRIPTION
## Summary
- finish `.e_step_r` to compute likelihoods and run forward–backward
- test that E‑step behaves the same under both engines

## Testing
- `devtools::test()` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bc97c488c832d9ffb7c40585afc3a