### PR TITLE
Add n_threads support to FISTA routines

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -16,8 +16,8 @@
 #' @return Gradient matrix (K x T)
 #' 
 #' @export
-compute_gradient_fista_rcpp <- function(Y_or_WtY, W, H_star_X, hrf_kernel, precomputed_WtY = FALSE, WtW_precomp) {
-    .Call(`_stance_compute_gradient_fista_rcpp`, Y_or_WtY, W, H_star_X, hrf_kernel, precomputed_WtY, WtW_precomp)
+compute_gradient_fista_rcpp <- function(Y_or_WtY, W, H_star_X, hrf_kernel, precomputed_WtY = FALSE, WtW_precomp, n_threads = 0L) {
+    .Call(`_stance_compute_gradient_fista_rcpp`, Y_or_WtY, W, H_star_X, hrf_kernel, precomputed_WtY, WtW_precomp, n_threads)
 }
 
 #' Compute FISTA Gradient with Pre-computed Terms
@@ -33,8 +33,8 @@ compute_gradient_fista_rcpp <- function(Y_or_WtY, W, H_star_X, hrf_kernel, preco
 #' @return Gradient matrix (K x T)
 #'
 #' @export
-compute_gradient_fista_precomp_rcpp <- function(WtY, WtW, H_star_X, hrf_kernel) {
-    .Call(`_stance_compute_gradient_fista_precomp_rcpp`, WtY, WtW, H_star_X, hrf_kernel)
+compute_gradient_fista_precomp_rcpp <- function(WtY, WtW, H_star_X, hrf_kernel, n_threads = 0L) {
+    .Call(`_stance_compute_gradient_fista_precomp_rcpp`, WtY, WtW, H_star_X, hrf_kernel, n_threads)
 }
 
 #' Transposed Convolution Helper
@@ -138,8 +138,8 @@ convolve_voxel_hrf_fft_rcpp <- function(design, hrfs, n_threads = 0L) {
 #'   - iterations: Number of iterations performed
 #' 
 #' @export
-fista_tv_rcpp <- function(WtY, W, hrf_kernel, lambda_tv, L_fista, X_init, max_iter = 100L, tol = 1e-4, verbose = FALSE) {
-    .Call(`_stance_fista_tv_rcpp`, WtY, W, hrf_kernel, lambda_tv, L_fista, X_init, max_iter, tol, verbose)
+fista_tv_rcpp <- function(WtY, W, hrf_kernel, lambda_tv, L_fista, X_init, max_iter = 100L, tol = 1e-4, verbose = FALSE, n_threads = 0L) {
+    .Call(`_stance_fista_tv_rcpp`, WtY, W, hrf_kernel, lambda_tv, L_fista, X_init, max_iter, tol, verbose, n_threads)
 }
 
 #' Compute CLD Objective Function

--- a/R/continuous_linear_decoder.R
+++ b/R/continuous_linear_decoder.R
@@ -135,7 +135,7 @@ ContinuousLinearDecoder <- R6::R6Class(
     #' @param verbose Logical, print iteration progress
     #'
     #' @return Self (invisibly) for method chaining
-    fit = function(max_iter = 100, tol = 1e-4, verbose = FALSE) {
+    fit = function(max_iter = 100, tol = 1e-4, verbose = FALSE, n_threads = 0L) {
       # Check if initialized
       if (!private$.use_low_rank && is.null(private$.W)) {
         stop("Model not initialized. Call $new() first.")
@@ -156,7 +156,8 @@ ContinuousLinearDecoder <- R6::R6Class(
       
       # Run FISTA optimization
       tryCatch({
-        private$.fista_tv(max_iter = max_iter, tol = tol, verbose = verbose)
+        private$.fista_tv(max_iter = max_iter, tol = tol, verbose = verbose,
+                          n_threads = n_threads)
         
         if (verbose) {
           cat("\nFISTA optimization complete.\n")
@@ -451,7 +452,7 @@ ContinuousLinearDecoder <- R6::R6Class(
     },
     
     #' Run FISTA optimization
-    .fista_tv = function(max_iter, tol, verbose) {
+    .fista_tv = function(max_iter, tol, verbose, n_threads = 0L) {
       # Check prerequisites
       if (is.null(private$.WtY) || is.null(private$.hrf)) {
         stop("Model not properly initialized. Run initialize() first.")
@@ -470,7 +471,8 @@ ContinuousLinearDecoder <- R6::R6Class(
         X_init = private$.X_hat,  # Use current X_hat as initialization
         max_iter = max_iter,
         tol = tol,
-        verbose = verbose
+        verbose = verbose,
+        n_threads = n_threads
       )
       
       # Store results

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -12,8 +12,8 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 // compute_gradient_fista_rcpp
-arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY, const arma::mat& W, const arma::mat& H_star_X, const arma::vec& hrf_kernel, bool precomputed_WtY, const arma::mat& WtW_precomp);
-RcppExport SEXP _stance_compute_gradient_fista_rcpp(SEXP Y_or_WtYSEXP, SEXP WSEXP, SEXP H_star_XSEXP, SEXP hrf_kernelSEXP, SEXP precomputed_WtYSEXP, SEXP WtW_precompSEXP) {
+arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY, const arma::mat& W, const arma::mat& H_star_X, const arma::vec& hrf_kernel, bool precomputed_WtY, const arma::mat& WtW_precomp, int n_threads);
+RcppExport SEXP _stance_compute_gradient_fista_rcpp(SEXP Y_or_WtYSEXP, SEXP WSEXP, SEXP H_star_XSEXP, SEXP hrf_kernelSEXP, SEXP precomputed_WtYSEXP, SEXP WtW_precompSEXP, SEXP n_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -23,7 +23,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const arma::vec& >::type hrf_kernel(hrf_kernelSEXP);
     Rcpp::traits::input_parameter< bool >::type precomputed_WtY(precomputed_WtYSEXP);
     Rcpp::traits::input_parameter< const arma::mat& >::type WtW_precomp(WtW_precompSEXP);
-    rcpp_result_gen = Rcpp::wrap(compute_gradient_fista_rcpp(Y_or_WtY, W, H_star_X, hrf_kernel, precomputed_WtY, WtW_precomp));
+    Rcpp::traits::input_parameter< int >::type n_threads(n_threadsSEXP);
+    rcpp_result_gen = Rcpp::wrap(compute_gradient_fista_rcpp(Y_or_WtY, W, H_star_X, hrf_kernel, precomputed_WtY, WtW_precomp, n_threads));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -58,8 +59,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // compute_gradient_fista_precomp_rcpp
-arma::mat compute_gradient_fista_precomp_rcpp(const arma::mat& WtY, const arma::mat& WtW, const arma::mat& H_star_X, const arma::vec& hrf_kernel);
-RcppExport SEXP _stance_compute_gradient_fista_precomp_rcpp(SEXP WtYSEXP, SEXP WtWSEXP, SEXP H_star_XSEXP, SEXP hrf_kernelSEXP) {
+arma::mat compute_gradient_fista_precomp_rcpp(const arma::mat& WtY, const arma::mat& WtW, const arma::mat& H_star_X, const arma::vec& hrf_kernel, int n_threads);
+RcppExport SEXP _stance_compute_gradient_fista_precomp_rcpp(SEXP WtYSEXP, SEXP WtWSEXP, SEXP H_star_XSEXP, SEXP hrf_kernelSEXP, SEXP n_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -67,7 +68,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const arma::mat& >::type WtW(WtWSEXP);
     Rcpp::traits::input_parameter< const arma::mat& >::type H_star_X(H_star_XSEXP);
     Rcpp::traits::input_parameter< const arma::vec& >::type hrf_kernel(hrf_kernelSEXP);
-    rcpp_result_gen = Rcpp::wrap(compute_gradient_fista_precomp_rcpp(WtY, WtW, H_star_X, hrf_kernel));
+    Rcpp::traits::input_parameter< int >::type n_threads(n_threadsSEXP);
+    rcpp_result_gen = Rcpp::wrap(compute_gradient_fista_precomp_rcpp(WtY, WtW, H_star_X, hrf_kernel, n_threads));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -127,8 +129,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // fista_tv_rcpp
-List fista_tv_rcpp(const arma::mat& WtY, const arma::mat& W, const arma::vec& hrf_kernel, double lambda_tv, double L_fista, const arma::mat& X_init, int max_iter, double tol, bool verbose);
-RcppExport SEXP _stance_fista_tv_rcpp(SEXP WtYSEXP, SEXP WSEXP, SEXP hrf_kernelSEXP, SEXP lambda_tvSEXP, SEXP L_fistaSEXP, SEXP X_initSEXP, SEXP max_iterSEXP, SEXP tolSEXP, SEXP verboseSEXP) {
+List fista_tv_rcpp(const arma::mat& WtY, const arma::mat& W, const arma::vec& hrf_kernel, double lambda_tv, double L_fista, const arma::mat& X_init, int max_iter, double tol, bool verbose, int n_threads);
+RcppExport SEXP _stance_fista_tv_rcpp(SEXP WtYSEXP, SEXP WSEXP, SEXP hrf_kernelSEXP, SEXP lambda_tvSEXP, SEXP L_fistaSEXP, SEXP X_initSEXP, SEXP max_iterSEXP, SEXP tolSEXP, SEXP verboseSEXP, SEXP n_threadsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -141,7 +143,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type max_iter(max_iterSEXP);
     Rcpp::traits::input_parameter< double >::type tol(tolSEXP);
     Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
-    rcpp_result_gen = Rcpp::wrap(fista_tv_rcpp(WtY, W, hrf_kernel, lambda_tv, L_fista, X_init, max_iter, tol, verbose));
+    Rcpp::traits::input_parameter< int >::type n_threads(n_threadsSEXP);
+    rcpp_result_gen = Rcpp::wrap(fista_tv_rcpp(WtY, W, hrf_kernel, lambda_tv, L_fista, X_init, max_iter, tol, verbose, n_threads));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -405,12 +408,12 @@ END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_stance_compute_gradient_fista_rcpp", (DL_FUNC) &_stance_compute_gradient_fista_rcpp, 6},
-    {"_stance_compute_gradient_fista_precomp_rcpp", (DL_FUNC) &_stance_compute_gradient_fista_precomp_rcpp, 4},
+    {"_stance_compute_gradient_fista_rcpp", (DL_FUNC) &_stance_compute_gradient_fista_rcpp, 7},
+    {"_stance_compute_gradient_fista_precomp_rcpp", (DL_FUNC) &_stance_compute_gradient_fista_precomp_rcpp, 5},
     {"_stance_convolve_transpose_rcpp", (DL_FUNC) &_stance_convolve_transpose_rcpp, 3},
     {"_stance_estimate_lipschitz_rcpp", (DL_FUNC) &_stance_estimate_lipschitz_rcpp, 4},
     {"_stance_convolve_rows_rcpp", (DL_FUNC) &_stance_convolve_rows_rcpp, 3},
-    {"_stance_fista_tv_rcpp", (DL_FUNC) &_stance_fista_tv_rcpp, 9},
+    {"_stance_fista_tv_rcpp", (DL_FUNC) &_stance_fista_tv_rcpp, 10},
     {"_stance_compute_objective_rcpp", (DL_FUNC) &_stance_compute_objective_rcpp, 5},
     {"_stance_estimate_lipschitz_lowrank_rcpp", (DL_FUNC) &_stance_estimate_lipschitz_lowrank_rcpp, 4},
     {"_stance_compute_WtY_lowrank_rcpp", (DL_FUNC) &_stance_compute_WtY_lowrank_rcpp, 4},

--- a/src/fista_gradient.cpp
+++ b/src/fista_gradient.cpp
@@ -16,7 +16,8 @@ arma::mat convolve_transpose_rcpp(const arma::mat& X, const arma::vec& hrf,
 arma::mat compute_gradient_fista_precomp_rcpp(const arma::mat& WtY,
                                               const arma::mat& WtW,
                                               const arma::mat& H_star_X,
-                                              const arma::vec& hrf_kernel);
+                                              const arma::vec& hrf_kernel,
+                                              int n_threads = 0);
 
 
 //' Compute FISTA Gradient for CLD
@@ -40,7 +41,8 @@ arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY,
                                       const arma::mat& H_star_X,
                                       const arma::vec& hrf_kernel,
                                       bool precomputed_WtY = false,
-                                      const arma::mat& WtW_precomp = arma::mat()) {
+                                      const arma::mat& WtW_precomp = arma::mat(),
+                                      int n_threads = 0) {
   
   // Input validation
   if (Y_or_WtY.is_empty() || W.is_empty() || H_star_X.is_empty() || hrf_kernel.is_empty()) {
@@ -85,7 +87,7 @@ arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY,
 
     // Apply transposed convolution with time-reversed HRF
     // Use automatic thread detection (0) for optimal parallelization
-    arma::mat Grad_L2 = convolve_transpose_rcpp(Grad_term, hrf_kernel, 0);
+    arma::mat Grad_L2 = convolve_transpose_rcpp(Grad_term, hrf_kernel, n_threads);
     return -Grad_L2;
 
   } else {
@@ -99,7 +101,8 @@ arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY,
 
     // Delegate to the simplified pre-computed interface
     return compute_gradient_fista_precomp_rcpp(Y_or_WtY, WtW,
-                                               H_star_X, hrf_kernel);
+                                               H_star_X, hrf_kernel,
+                                               n_threads);
   }
 }
 
@@ -120,7 +123,8 @@ arma::mat compute_gradient_fista_rcpp(const arma::mat& Y_or_WtY,
 arma::mat compute_gradient_fista_precomp_rcpp(const arma::mat& WtY,
                                               const arma::mat& WtW,
                                               const arma::mat& H_star_X,
-                                              const arma::vec& hrf_kernel) {
+                                              const arma::vec& hrf_kernel,
+                                              int n_threads = 0) {
   // Input validation
   if (WtY.is_empty() || WtW.is_empty() || H_star_X.is_empty() ||
       hrf_kernel.is_empty()) {
@@ -140,7 +144,7 @@ arma::mat compute_gradient_fista_precomp_rcpp(const arma::mat& WtY,
   // Apply transposed convolution with time-reversed HRF
 
   // This is the gradient with respect to X (before convolution)
-  arma::mat Grad_L2 = convolve_transpose_rcpp(Grad_term, hrf_kernel, 0);
+  arma::mat Grad_L2 = convolve_transpose_rcpp(Grad_term, hrf_kernel, n_threads);
   
 
   return -Grad_L2;

--- a/tests/testthat/test-fista-multithread.R
+++ b/tests/testthat/test-fista-multithread.R
@@ -1,0 +1,41 @@
+library(stance)
+
+test_that("fista_tv_rcpp multi-threading matches single-thread", {
+  skip_if_not(exists("fista_tv_rcpp"), "Rcpp functions not compiled")
+  openmp_info <- check_openmp_support()
+  if (openmp_info$available) {
+    set.seed(123)
+    V <- 20; T_len <- 30; K <- 3
+    Y <- matrix(rnorm(V * T_len), V, T_len)
+    W <- matrix(rnorm(V * K), V, K)
+    hrf <- rep(1/3, 3)
+    WtY <- t(W) %*% Y
+    L <- estimate_lipschitz_rcpp(W, hrf)
+    X_init <- matrix(0, K, T_len)
+    res1 <- fista_tv_rcpp(WtY, W, hrf, 0.01, L, X_init,
+                          max_iter = 5L, tol = 1e-4,
+                          verbose = FALSE, n_threads = 1L)
+    res2 <- fista_tv_rcpp(WtY, W, hrf, 0.01, L, X_init,
+                          max_iter = 5L, tol = 1e-4,
+                          verbose = FALSE, n_threads = 2L)
+    expect_equal(res1$X_hat, res2$X_hat, tolerance = 1e-6)
+  }
+})
+
+test_that("compute_gradient_fista_precomp_rcpp multi-threading", {
+  skip_if_not(exists("compute_gradient_fista_precomp_rcpp"), "Rcpp functions not compiled")
+  openmp_info <- check_openmp_support()
+  if (openmp_info$available) {
+    set.seed(456)
+    K <- 2; T_len <- 20; V <- 5
+    W <- matrix(rnorm(V * K), V, K)
+    X <- matrix(rnorm(K * T_len), K, T_len)
+    hrf <- c(0.2, 0.5, 0.3)
+    H_star_X <- convolve_rows_rcpp(X, hrf, n_threads = 1L)
+    WtW <- t(W) %*% W
+    WtY <- WtW %*% H_star_X
+    grad1 <- compute_gradient_fista_precomp_rcpp(WtY, WtW, H_star_X, hrf, n_threads = 1L)
+    grad2 <- compute_gradient_fista_precomp_rcpp(WtY, WtW, H_star_X, hrf, n_threads = 2L)
+    expect_equal(grad1, grad2, tolerance = 1e-8)
+  }
+})


### PR DESCRIPTION
## Summary
- allow `fista_tv_rcpp`, `compute_gradient_fista_rcpp`, and `compute_gradient_fista_precomp_rcpp` to accept `n_threads`
- propagate threading options to convolution helpers
- expose new arguments in R wrappers
- pass thread count from CLD class
- add regression tests for multithreaded FISTA paths

## Testing
- `Rscript -e "testthat::test_package('stance')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c5872fd94832daef66246d2faab8f