### PR TITLE
Add batch_size validation to CBD fit

### DIFF
--- a/R/continuous_bayesian_decoder.R
+++ b/R/continuous_bayesian_decoder.R
@@ -165,6 +165,9 @@ ContinuousBayesianDecoder <- R6::R6Class(
         }
       } else {
         T_total <- private$.T
+        if (batch_size > T_total) {
+          stop("batch_size must be less than or equal to the number of timepoints")
+        }
         if (batch_size < 100 || batch_size > T_total/2) {
           warning("Batch size should be 100-150 for optimal performance")
         }

--- a/tests/testthat/test-cbd-batch-size.R
+++ b/tests/testthat/test-cbd-batch-size.R
@@ -1,0 +1,11 @@
+library(testthat)
+library(stance)
+
+test_that("fit() errors when batch_size exceeds timepoints", {
+  sim <- simulate_fmri_data(V = 10, T = 20, K = 2, algorithm = "CBD", verbose = FALSE)
+  cbd <- ContinuousBayesianDecoder$new(Y = sim$Y, K = 2, r = 2)
+  expect_error(
+    cbd$fit(max_iter = 1, verbose = FALSE, batch_size = 25),
+    "batch_size must be less than or equal to the number of timepoints"
+  )
+})


### PR DESCRIPTION
## Summary
- validate `batch_size` is not greater than total timepoints
- add regression test for batch size input validation

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c58918824832dbaa867fb07e34d76