### PR TITLE
Add tests for untested utilities

### DIFF
--- a/tests/testthat/test-diagnostic-utils.R
+++ b/tests/testthat/test-diagnostic-utils.R
@@ -37,3 +37,13 @@ test_that("recommend_parameters returns informative message", {
   expect_match(rec, "dataset of size 5 x 8")
 })
 
+test_that("generate_diagnostic_report writes html output", {
+  diag_list <- list(a = 1, b = 2)
+  out_dir <- tempfile("diag")
+  path <- stance:::generate_diagnostic_report(diag_list, out_dir)
+  expect_true(file.exists(path))
+  content <- readLines(path)
+  expect_true(any(grepl("<h1>Model Diagnostics</h1>", content)))
+  expect_true(any(grepl("a", content)))
+})
+

--- a/tests/testthat/test-hrf_utils.R
+++ b/tests/testthat/test-hrf_utils.R
@@ -178,3 +178,11 @@ test_that("create_hrf_basis_fir handles TR drift edge cases", {
   expect_equal(nrow(basis), floor(31 / 0.7) + 1)
   expect_true(ncol(basis) >= 1)
 })
+
+test_that("create_hrf_basis_neuroim2 delegates to hrf_basis_matrix", {
+  basis_neuro <- create_hrf_basis_neuroim2("spmg3", TR = 1, duration = 16)
+  basis_ref   <- hrf_basis_matrix("spmg3", TR = 1, len = 16)
+  expect_equal(basis_neuro, basis_ref)
+  expect_equal(attr(basis_neuro, "basis_type"), "spmg3")
+  expect_equal(attr(basis_neuro, "TR"), 1)
+})

--- a/tests/testthat/test-run-integration-tests.R
+++ b/tests/testthat/test-run-integration-tests.R
@@ -1,0 +1,19 @@
+library(testthat)
+library(stance)
+
+# Test run_integration_tests wrapper
+
+test_that("run_integration_tests executes configurations", {
+  sim <- simulate_fmri_data(V = 8, T = 10, K = 2, algorithm = "CBD", verbose = FALSE)
+  configs <- list(
+    base = list(use_gmrf = FALSE, use_rcpp = FALSE),
+    base2 = list(use_gmrf = FALSE, use_rcpp = FALSE)
+  )
+  res <- run_integration_tests(configs, sim, max_iter = 1)
+  expect_type(res, "list")
+  expect_equal(names(res), names(configs))
+  for (r in res) {
+    expect_true(is.numeric(r$time))
+    expect_true(is.logical(r$converged))
+  }
+})


### PR DESCRIPTION
## Summary
- expand hrf utils tests to check `create_hrf_basis_neuroim2`
- add a diagnostic report output test
- test `run_integration_tests` wrapper

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b53784a70832d920d50895d7a750a